### PR TITLE
Allow Pixmap to be backed by an unowned slice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .idea
 *.iml
 /image.png
+/image-shm.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Changed
 - Improve clipping performance.
+- Add support for drawing to user-supplied slice.
 
 ## 0.2.0 - 2020-11-16
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ default = ["png-format"]
 
 # Allows loading and saving `Pixmap` as PNG.
 png-format = ["png"]
+
+[dev-dependencies]
+memmap = "0.7"
+tempfile = "3.1"
+nix = "0.19"

--- a/examples/image_on_image.rs
+++ b/examples/image_on_image.rs
@@ -18,7 +18,7 @@ fn main() {
     canvas.pixmap.save_png("image.png").unwrap();
 }
 
-fn crate_triangle() -> Pixmap {
+fn crate_triangle() -> Pixmap<'static> {
     let mut canvas = Canvas::new(200, 200).unwrap();
 
     let mut paint = Paint::default();

--- a/examples/pattern.rs
+++ b/examples/pattern.rs
@@ -26,7 +26,7 @@ fn main() {
     canvas.pixmap.save_png("image.png").unwrap();
 }
 
-fn crate_triangle() -> Pixmap {
+fn crate_triangle() -> Pixmap<'static> {
     let mut canvas = Canvas::new(20, 20).unwrap();
 
     let mut paint = Paint::default();

--- a/examples/shm_client.rs
+++ b/examples/shm_client.rs
@@ -1,0 +1,87 @@
+use nix::sys::uio::IoVec;
+use tiny_skia::*;
+use nix::sys::socket::{
+    sendmsg,
+    ControlMessage,
+    MsgFlags,
+};
+use std::os::unix::{
+    io::AsRawFd,
+    net::UnixStream,
+};
+
+/// This example demonstrates drawing with skia using a shared memory region.
+///
+/// It consists of two parts:
+/// 1. `shm_client`: Draws an image onto a shared memory region.
+/// 2. `shm_server`: Writes the image from the shared memory region to a PNG file ("image-shm.png").
+///
+/// To run the example, you'll need two terminal windows.
+///
+/// In one of the windows, run the shm_server example:
+///
+///     cargo run --example shm_server
+///
+/// Keep that example running, and run shm_client in the second window:
+///
+///     cargo run --example shm_client
+///
+/// After the command returns, you should see a message in the server window, and image-shm.png contains the image
+/// that was drawn by the client.
+///
+/// You can press CTRL+C to terminate the server.
+fn main() {
+    // If you change this, make sure to modify the corresponding values in `shm_server.rs` as well:
+    let width = 1000;
+    let height = 1000;
+
+    let file = tempfile::tempfile().unwrap();
+    file.set_len((width * height * 4) as u64).unwrap();
+
+    let mut mmap = unsafe { memmap::MmapOptions::new().map_mut(&file) }.unwrap();
+
+    let pixmap = Pixmap::from_data(width, height, &mut mmap).unwrap();
+    let mut canvas: Canvas = pixmap.into();
+
+    let mut paint1 = Paint::default();
+    paint1.set_color_rgba8(50, 127, 150, 200);
+    paint1.anti_alias = true;
+
+    let mut paint2 = Paint::default();
+    paint2.set_color_rgba8(220, 140, 75, 180);
+
+    let path1 = {
+        let mut pb = PathBuilder::new();
+        pb.move_to(60.0, 60.0);
+        pb.line_to(160.0, 940.0);
+        pb.cubic_to(380.0, 840.0, 660.0, 800.0, 940.0, 800.0);
+        pb.cubic_to(740.0, 460.0, 440.0, 160.0, 60.0, 60.0);
+        pb.close();
+        pb.finish().unwrap()
+    };
+
+    let path2 = {
+        let mut pb = PathBuilder::new();
+        pb.move_to(940.0, 60.0);
+        pb.line_to(840.0, 940.0);
+        pb.cubic_to(620.0, 840.0, 340.0, 800.0, 60.0, 800.0);
+        pb.cubic_to(260.0, 460.0, 560.0, 160.0, 940.0, 60.0);
+        pb.close();
+        pb.finish().unwrap()
+    };
+
+    canvas.fill_path(&path1, &paint1, FillRule::Winding);
+    canvas.fill_path(&path2, &paint2, FillRule::Winding);
+
+    let socket = UnixStream::connect("./shm-example.sock")
+        .expect("Failed to connect to ./shm-example.sock. Is shm_server example running?");
+
+    sendmsg(
+        socket.as_raw_fd(),
+        // Even though we only want to send a control message, the payload must have at least 1 byte.
+        &[IoVec::from_slice(&[0; 1])],
+        &[ControlMessage::ScmRights(&[file.as_raw_fd()])],
+        MsgFlags::empty(),
+        None
+    ).expect("Failed to send message to socket");
+}

--- a/examples/shm_server.rs
+++ b/examples/shm_server.rs
@@ -1,0 +1,50 @@
+use std::os::unix::{
+    io::{AsRawFd, RawFd, FromRawFd},
+    net::UnixListener,
+};
+use tiny_skia::*;
+use nix::sys::socket::{recvmsg, ControlMessageOwned, MsgFlags};
+use nix::cmsg_space;
+
+/// This is part of a two-part example. See `shm_client.rs` for documentation.
+fn main() -> std::io::Result<()> {
+    // If you change this, make sure to modify the corresponding values in `shm_client.rs` as well:
+    let width = 1000;
+    let height = 1000;
+
+    let socket_path = std::path::Path::new("./shm-example.sock");
+    if socket_path.exists() {
+        std::fs::remove_file(&socket_path).unwrap();
+    }
+    let listener = UnixListener::bind(&socket_path)?;
+
+    println!("Waiting for client");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                let mut cmsg_buffer = cmsg_space!([RawFd; 1]);
+                let received = recvmsg(stream.as_raw_fd(), &[], Some(&mut cmsg_buffer), MsgFlags::empty()).unwrap();
+                for cmsg in received.cmsgs() {
+                    match cmsg {
+                        ControlMessageOwned::ScmRights(fds) => {
+                            let mut mmap = unsafe {
+                                let file = std::fs::File::from_raw_fd(fds[0]);
+                                memmap::MmapOptions::new().map_mut(&file)
+                            }.unwrap();
+                            let pixmap = Pixmap::from_data(width, height, &mut mmap).unwrap();
+                            pixmap.save_png("image-shm.png").unwrap();
+                            println!("Wrote to image-shm.png");
+                        },
+                        _ => {}
+                    }
+                }
+            }
+            Err(err) => {
+                println!("Failed to accept stream: {:?}", err);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -56,9 +56,9 @@ impl Default for PixmapPaint {
 /// and a caller has no way of checking it.
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
-pub struct Canvas {
+pub struct Canvas<'a> {
     /// A pixmap owned by the canvas.
-    pub pixmap: Pixmap,
+    pub pixmap: Pixmap<'a>,
 
     /// Canvas's transform.
     transform: Transform,
@@ -71,9 +71,9 @@ pub struct Canvas {
     stroked_path: Option<Path>,
 }
 
-impl From<Pixmap> for Canvas {
+impl<'a> From<Pixmap<'a>> for Canvas<'a> {
     #[inline]
-    fn from(pixmap: Pixmap) -> Self {
+    fn from(pixmap: Pixmap<'a>) -> Self {
         Canvas {
             pixmap,
             transform: Transform::identity(),
@@ -84,7 +84,7 @@ impl From<Pixmap> for Canvas {
     }
 }
 
-impl Canvas {
+impl Canvas<'_> {
     /// Creates a new canvas.
     ///
     /// A canvas is filled with transparent black by default, aka (0, 0, 0, 0).

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -103,7 +103,7 @@ impl<'a> Paint<'a> {
 }
 
 
-impl Pixmap {
+impl Pixmap<'_> {
     /// Draws a filled rectangle onto the pixmap.
     ///
     /// This function is usually slower than filling a rectangular path,

--- a/src/shaders/pattern.rs
+++ b/src/shaders/pattern.rs
@@ -31,7 +31,7 @@ pub enum FilterQuality {
 /// mipmap generation, which adds too much complexity.
 #[derive(Clone, Debug)]
 pub struct Pattern<'a> {
-    pixmap: &'a Pixmap,
+    pixmap: &'a Pixmap<'a>,
     quality: FilterQuality,
     spread_mode: SpreadMode,
     pub(crate) opacity: NormalizedF32,
@@ -49,8 +49,8 @@ impl<'a> Pattern<'a> {
         quality: FilterQuality,
         opacity: f32,
         transform: Transform,
-    ) -> Shader {
-        Shader::Pattern(Pattern {
+    ) -> Shader<'a> {
+        Shader::Pattern(Pattern::<'a> {
             pixmap,
             spread_mode,
             quality,

--- a/tests/hairline.rs
+++ b/tests/hairline.rs
@@ -1,6 +1,6 @@
 use tiny_skia::*;
 
-fn draw_line(x0: f32, y0: f32, x1: f32, y1: f32, anti_alias: bool, width: f32, line_cap: LineCap) -> Pixmap {
+fn draw_line(x0: f32, y0: f32, x1: f32, y1: f32, anti_alias: bool, width: f32, line_cap: LineCap) -> Pixmap<'static> {
     let mut canvas = Canvas::new(100, 100).unwrap();
 
     let mut pb = PathBuilder::new();
@@ -104,7 +104,7 @@ fn clip_vline_right_aa() {
     assert_eq!(draw_line(100.0, -1.0, 100.0, 101.0, true, 1.0, LineCap::Butt), expected);
 }
 
-fn draw_quad(anti_alias: bool, width: f32, line_cap: LineCap) -> Pixmap {
+fn draw_quad(anti_alias: bool, width: f32, line_cap: LineCap) -> Pixmap<'static> {
     let mut canvas = Canvas::new(200, 100).unwrap();
 
     let mut pb = PathBuilder::new();

--- a/tests/pattern.rs
+++ b/tests/pattern.rs
@@ -1,6 +1,6 @@
 use tiny_skia::*;
 
-fn crate_triangle() -> Pixmap {
+fn crate_triangle() -> Pixmap<'static> {
     let mut canvas = Canvas::new(20, 20).unwrap();
 
     let mut paint = Paint::default();

--- a/tests/pixmap.rs
+++ b/tests/pixmap.rs
@@ -66,3 +66,18 @@ fn fill() {
     pixmap.fill(c);
     assert_eq!(pixmap.pixel(1, 1).unwrap(), c.premultiply().to_color_u8());
 }
+
+#[test]
+fn unowned_pixmap() {
+    let c = Color::from_rgba8(50, 100, 150, 200);
+    let mut data = vec![0; 10*10*4];
+    {
+        // Create a pixmap and fill with color:
+        let mut pixmap = Pixmap::from_data(10, 10, data.as_mut_slice()).unwrap();
+        pixmap.fill(c);
+    }
+
+    // Create another pixmap, backed by the same data, and verify it has the right color:
+    let pixmap = Pixmap::from_data(10, 10, data.as_mut_slice()).unwrap();
+    assert_eq!(pixmap.pixel(1, 1).unwrap(), c.premultiply().to_color_u8())
+}


### PR DESCRIPTION
First of all, thank you for a great drawing library. I've tried a few alternatives, and this seems a very promising project.

Something I found lacking though is the ability to draw onto a surface that is not managed by the library itself, like cairo's [`cairo_image_surface_create_for_data`](https://cairographics.org/manual/cairo-Image-Surfaces.html#cairo-image-surface-create-for-data) does.

The changes in this PR are my attempt to add that ability.
The basic idea is that a `Pixmap` can be backed by either a `Vec<u8>` (which it owns) or by a `&mut [u8]` slice (which it does not own). A `Pixmap` with unowned data can be created with:
```rust
let pixmap = Pixmap::from_data(800, 600, &mut my_u8_slice);
```

There are a number of reasons why this can be useful, such as:
- Drawing to a [framebuffer device](https://en.wikipedia.org/wiki/Linux_framebuffer), which usually works by mapping the `/dev/fbX` device into memory using `mmap` and then drawing to the mapped region.
- Drawing to shared memory. I've added an example for this, which is a bit contrived. A real world use-case would be writing applications for wayland, which [uses shared memory pools](https://wayland-book.com/surfaces/shared-memory.html) to let clients draw onto surfaces.
- Mixing tiny-skia with other drawing libraries (such as for text rendering, as you mention in #16).

