### PR TITLE
Make concat() not returning an Option

### DIFF
--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -119,9 +119,7 @@ impl<'a> Canvas<'a> {
     /// Applies an affine transformation to the canvas.
     #[inline]
     pub fn apply_transform(&mut self, ts: &Transform) {
-        if let Some(ts) = self.transform.pre_concat(ts) {
-            self.transform = ts;
-        }
+        self.transform = self.transform.pre_concat(ts)
     }
 
     /// Gets the current canvas transform.

--- a/src/floating_point.rs
+++ b/src/floating_point.rs
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use std::ops::{Add, Mul};
+
 use crate::scalar::Scalar;
 
 pub const FLOAT_PI: f32 = 3.14159265;
@@ -162,6 +164,22 @@ impl PartialOrd for FiniteF32 {
     #[inline]
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+impl Add for FiniteF32 {
+    type Output = Self;
+
+    fn add(self, other: Self) -> Self {
+        Self::new(self.get() + other.get()).unwrap()
+    }
+}
+
+impl Mul for FiniteF32 {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self {
+        Self::new(self.get() * rhs.get()).unwrap()
     }
 }
 

--- a/src/path_geometry.rs
+++ b/src/path_geometry.rs
@@ -950,7 +950,7 @@ impl Conic {
             transform = transform.pre_scale(1.0, -1.0)?;
         }
 
-        transform = transform.post_concat(user_transform)?;
+        transform = transform.post_concat(user_transform);
 
         for conic in dst.iter_mut().take(conic_count) {
             transform.map_points(&mut conic.points);

--- a/src/shaders/gradient.rs
+++ b/src/shaders/gradient.rs
@@ -110,7 +110,7 @@ impl Gradient {
         p.push(pipeline::Stage::SeedShader);
 
         let ts = self.transform.invert()?;
-        let ts = ts.post_concat(&self.points_to_unit)?;
+        let ts = ts.post_concat(&self.points_to_unit);
         p.push_transform(ts);
 
         push_stages_pre(p);

--- a/src/shaders/mod.rs
+++ b/src/shaders/mod.rs
@@ -95,19 +95,13 @@ impl<'a> Shader<'a> {
         match self {
             Shader::SolidColor(_) => {}
             Shader::LinearGradient(g) => {
-                if let Some(ts) = g.base.transform.post_concat(ts) {
-                    g.base.transform = ts;
-                }
+                g.base.transform = g.base.transform.post_concat(ts)
             }
             Shader::RadialGradient(g) => {
-                if let Some(ts) = g.base.transform.post_concat(ts) {
-                    g.base.transform = ts;
-                }
+                g.base.transform = g.base.transform.post_concat(ts)
             }
             Shader::Pattern(p) => {
-                if let Some(ts) = p.transform.post_concat(ts) {
-                    p.transform = ts;
-                }
+                p.transform = p.transform.post_concat(ts)
             }
         }
     }


### PR DESCRIPTION
`concat()` now always returns a value as it is safe to concat to transformations.

When using tiny-skia, I was wondering why `concat()` returned an `Option`, so I thought I change that. Though I'm still unsure if that's correct or whether there was a reason why it returned an option.