### PR TITLE
Implement no_std support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,8 +23,8 @@ jobs:
         toolchain: ${{ matrix.rust }}
         override: true
 
-    - name: Build without default features
-      run: cargo build --verbose --no-default-features
+    - name: Build with minimal features (no_std)
+      run: cargo build --verbose --no-default-features --features libm
 
     - name: Run tests without SIMD
       run: cargo test --verbose --no-default-features --features png-format

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,23 @@ categories = ["rendering"]
 
 [dependencies]
 arrayref = "0.3"
-arrayvec = "0.5"
+arrayvec = { version = "0.5", default-features = false }
 bytemuck = "1.4"
 cfg-if = "1"
 png = { version = "0.16", optional = true }
 safe_arch = { version = "0.5.2", features = ["bytemuck"], optional = true }
+libm = { version = "0.2.1", optional = true }
 
 [features]
-default = ["simd", "png-format"]
+default = ["std", "simd", "png-format"]
+
+# Enables the use of the standard library. Deactivate this and activate the libm
+# feature to compile for targets that don't have std.
+std = []
 
 # Enables x86 SIMD instructions from SSE up to AVX2.
 # Has no effect on non-x86 targets. Present mainly for testing.
 simd = ["safe_arch"]
 
 # Allows loading and saving `Pixmap` as PNG.
-png-format = ["png"]
+png-format = ["std", "png"]

--- a/src/alpha_runs.rs
+++ b/src/alpha_runs.rs
@@ -4,8 +4,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::TryFrom;
-use std::num::NonZeroU16;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::convert::TryFrom;
+use core::num::NonZeroU16;
 
 use crate::LengthU32;
 use crate::color::AlphaU8;

--- a/src/clip.rs
+++ b/src/clip.rs
@@ -3,6 +3,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use alloc::vec::Vec;
+
 use crate::{Path, LengthU32, FillRule};
 use crate::{ALPHA_U8_OPAQUE, ALPHA_U8_TRANSPARENT};
 
@@ -11,7 +13,7 @@ use crate::blitter::Blitter;
 use crate::color::AlphaU8;
 use crate::geom::ScreenIntRect;
 use crate::math::LENGTH_U32_ONE;
-use std::num::NonZeroU32;
+use core::num::NonZeroU32;
 
 #[derive(Clone, Debug)]
 pub struct ClipMaskData {

--- a/src/color.rs
+++ b/src/color.rs
@@ -83,8 +83,8 @@ impl ColorU8 {
     }
 }
 
-impl std::fmt::Debug for ColorU8 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for ColorU8 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ColorU8")
             .field("r", &self.red())
             .field("g", &self.green())
@@ -181,8 +181,8 @@ impl PremultipliedColorU8 {
     }
 }
 
-impl std::fmt::Debug for PremultipliedColorU8 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PremultipliedColorU8 {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PremultipliedColorU8")
             .field("r", &self.red())
             .field("g", &self.green())

--- a/src/dash.rs
+++ b/src/dash.rs
@@ -6,6 +6,8 @@
 
 // This module is a mix of SkDashPath, SkDashPathEffect, SkContourMeasure and SkPathMeasure.
 
+use alloc::vec::Vec;
+
 use arrayref::array_ref;
 
 use crate::{Path, PathSegment, PathSegmentsIter, Point, PathBuilder};
@@ -14,6 +16,9 @@ use crate::floating_point::{NormalizedF32, NonZeroPositiveF32, FiniteF32, Normal
 use crate::path::PathVerb;
 use crate::path_geometry;
 use crate::scalar::Scalar;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 /// A stroke dashing properties.
 ///
@@ -74,6 +79,7 @@ impl StrokeDash {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use alloc::vec;
 
     #[test]
     fn test() {

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -41,7 +41,7 @@ impl Edge {
     }
 }
 
-impl std::ops::Deref for Edge {
+impl core::ops::Deref for Edge {
     type Target = LineEdge;
 
     fn deref(&self) -> &Self::Target {
@@ -49,7 +49,7 @@ impl std::ops::Deref for Edge {
     }
 }
 
-impl std::ops::DerefMut for Edge {
+impl core::ops::DerefMut for Edge {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.as_line_mut()
     }
@@ -80,8 +80,8 @@ impl LineEdge {
         let mut winding = 1;
 
         if y0 > y1 {
-            std::mem::swap(&mut x0, &mut x1);
-            std::mem::swap(&mut y0, &mut y1);
+            core::mem::swap(&mut x0, &mut x1);
+            core::mem::swap(&mut y0, &mut y1);
             winding = -1;
         }
 
@@ -179,8 +179,8 @@ impl QuadraticEdge {
 
         let mut winding = 1;
         if y0 > y2 {
-            std::mem::swap(&mut x0, &mut x2);
-            std::mem::swap(&mut y0, &mut y2);
+            core::mem::swap(&mut x0, &mut x2);
+            core::mem::swap(&mut y0, &mut y2);
             winding = -1;
         }
         debug_assert!(y0 <= y1 && y1 <= y2);
@@ -357,10 +357,10 @@ impl CubicEdge {
 
         let mut winding = 1;
         if sort_y && y0 > y3 {
-            std::mem::swap(&mut x0, &mut x3);
-            std::mem::swap(&mut x1, &mut x2);
-            std::mem::swap(&mut y0, &mut y3);
-            std::mem::swap(&mut y1, &mut y2);
+            core::mem::swap(&mut x0, &mut x3);
+            core::mem::swap(&mut x1, &mut x2);
+            core::mem::swap(&mut y0, &mut y3);
+            core::mem::swap(&mut y1, &mut y2);
             winding = -1;
         }
 

--- a/src/edge_builder.rs
+++ b/src/edge_builder.rs
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use alloc::vec::Vec;
+
 use crate::{Point, Path};
 
 use crate::edge::{Edge, LineEdge, QuadraticEdge, CubicEdge};

--- a/src/edge_clipper.rs
+++ b/src/edge_clipper.rs
@@ -14,6 +14,9 @@ use crate::path::{PathEdge, PathEdgeIter};
 use crate::path_geometry;
 use crate::scalar::SCALAR_MAX;
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 // This is a fail-safe `arr[n..n+3].try_into().unwrap()` alternative.
 // Everything is checked at compile-time so there is no bound checking and panics.
 macro_rules! copy_3_points {
@@ -75,7 +78,7 @@ impl EdgeClipper {
 
     fn push_vline(&mut self, x: f32, mut y0: f32, mut y1: f32, reverse: bool) {
         if reverse {
-            std::mem::swap(&mut y0, &mut y1);
+            core::mem::swap(&mut y0, &mut y1);
         }
 
         self.edges.push(PathEdge::LineTo(Point::from_xy(x, y0), Point::from_xy(x, y1)));

--- a/src/fixed_point.rs
+++ b/src/fixed_point.rs
@@ -21,7 +21,7 @@ pub type FDot16 = i32;
 
 pub mod fdot6 {
     use super::*;
-    use std::convert::TryFrom;
+    use core::convert::TryFrom;
 
     pub const ONE: FDot6 = 64;
 
@@ -62,7 +62,7 @@ pub mod fdot6 {
     }
 
     pub fn can_convert_to_fdot16(n: FDot6) -> bool {
-        let max_dot6 = std::i32::MAX >> (16 - 6);
+        let max_dot6 = core::i32::MAX >> (16 - 6);
         n.abs() <= max_dot6
     }
 

--- a/src/floating_point.rs
+++ b/src/floating_point.rs
@@ -6,6 +6,9 @@
 
 use crate::scalar::Scalar;
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 pub const FLOAT_PI: f32 = 3.14159265;
 
 const MAX_I32_FITS_IN_F32: f32 = 2147483520.0;
@@ -86,14 +89,14 @@ fn sign_bit_to_2s_compliment(mut x: i32) -> i32 {
 
 macro_rules! impl_debug_display {
     ($t:ident) => {
-        impl std::fmt::Debug for $t {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Debug for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self.get())
             }
         }
 
-        impl std::fmt::Display for $t {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        impl core::fmt::Display for $t {
+            fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 write!(f, "{}", self.get())
             }
         }
@@ -138,19 +141,19 @@ impl PartialEq for FiniteF32 {
 }
 
 impl Ord for FiniteF32 {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
         if self.0 < other.0 {
-            std::cmp::Ordering::Less
+            core::cmp::Ordering::Less
         } else if self.0 > other.0 {
-            std::cmp::Ordering::Greater
+            core::cmp::Ordering::Greater
         } else {
-            std::cmp::Ordering::Equal
+            core::cmp::Ordering::Equal
         }
     }
 }
 
 impl PartialOrd for FiniteF32 {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         Some(self.cmp(other))
     }
 }
@@ -226,7 +229,7 @@ impl NormalizedF32Exclusive {
     }
 
     pub fn new_bounded(n: f32) -> Self {
-        let n = n.bound(std::f32::EPSILON, 1.0 - std::f32::EPSILON);
+        let n = n.bound(core::f32::EPSILON, 1.0 - core::f32::EPSILON);
         // `n` is guarantee to be finite after clamping.
         debug_assert!(n.is_finite());
         NormalizedF32Exclusive(FiniteF32(n))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ and a user should manage the world transform, clipping mask and style manually.
 See the `examples/` directory for usage examples.
 */
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/tiny-skia/0.4.2")]
 #![warn(missing_docs)]
 #![warn(missing_copy_implementations)]
@@ -26,6 +27,14 @@ See the `examples/` directory for usage examples.
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::neg_cmp_op_on_partial_ord)]
 #![allow(clippy::too_many_arguments)]
+
+#[cfg(not(any(feature = "std", feature = "libm")))]
+compile_error!("You have to activate either the `std` or the `libm` feature.");
+
+#[cfg(feature = "std")]
+extern crate std;
+
+extern crate alloc;
 
 mod alpha_runs;
 mod blend_mode;
@@ -71,4 +80,4 @@ pub use stroker::{LineCap, LineJoin, Stroke};
 pub use transform::Transform;
 
 /// An integer length that is guarantee to be > 0
-type LengthU32 = std::num::NonZeroU32;
+type LengthU32 = core::num::NonZeroU32;

--- a/src/line_clipper.rs
+++ b/src/line_clipper.rs
@@ -193,7 +193,7 @@ fn sect_with_vertical(src: &[Point; 2], x: f32) -> f32 {
 
 fn pin_unsorted_f32(value: f32, mut limit0: f32, mut limit1: f32) -> f32 {
     if limit1 < limit0 {
-        std::mem::swap(&mut limit0, &mut limit1);
+        core::mem::swap(&mut limit0, &mut limit1);
     }
     // now the limits are sorted
     debug_assert!(limit0 <= limit1);
@@ -209,7 +209,7 @@ fn pin_unsorted_f32(value: f32, mut limit0: f32, mut limit1: f32) -> f32 {
 
 fn pin_unsorted_f64(value: f64, mut limit0: f64, mut limit1: f64) -> f64 {
     if limit1 < limit0 {
-        std::mem::swap(&mut limit0, &mut limit1);
+        core::mem::swap(&mut limit0, &mut limit1);
     }
     // now the limits are sorted
     debug_assert!(limit0 <= limit1);

--- a/src/painter.rs
+++ b/src/painter.rs
@@ -11,6 +11,9 @@ use crate::scalar::Scalar;
 use crate::scan;
 use crate::stroker::PathStroker;
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 // 8K is 1 too big, since 8K << supersample == 32768 which is too big for Fixed.
 const MAX_DIM: u32 = 8192 - 1;
 
@@ -385,7 +388,7 @@ fn treat_as_hairline(paint: &Paint, stroke: &Stroke, mut ts: Transform) -> Optio
         let mut x = p.x.abs();
         let mut y = p.y.abs();
         if x < y {
-            std::mem::swap(&mut x, &mut y);
+            core::mem::swap(&mut x, &mut y);
         }
 
         x + y.half()

--- a/src/path.rs
+++ b/src/path.rs
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use alloc::vec::Vec;
+
 use crate::{Point, PathBuilder, Rect, Transform};
 
 use crate::scalar::SCALAR_MAX;
@@ -131,11 +133,11 @@ impl Path {
     }
 }
 
-impl std::fmt::Debug for Path {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        use std::fmt::Write;
+impl core::fmt::Debug for Path {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        use core::fmt::Write;
 
-        let mut s = String::new();
+        let mut s = alloc::string::String::new();
         for segment in self.segments() {
             match segment {
                 PathSegment::MoveTo(p) =>

--- a/src/path64/cubic64.rs
+++ b/src/path64/cubic64.rs
@@ -8,6 +8,9 @@ use super::Scalar64;
 use super::point64::{Point64, SearchAxis};
 use super::quad64;
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 pub const POINT_COUNT: usize = 4;
 const PI: f64 = 3.141592653589793;
 
@@ -360,13 +363,13 @@ pub fn find_extrema(src: &[f64], t_values: &mut [f64]) -> usize {
 }
 
 // Skia doesn't seems to care about NaN/inf during sorting, so we don't too.
-fn cmp_f64(a: &f64, b: &f64) -> std::cmp::Ordering {
+fn cmp_f64(a: &f64, b: &f64) -> core::cmp::Ordering {
     if a < b {
-        std::cmp::Ordering::Less
+        core::cmp::Ordering::Less
     } else if a > b {
-        std::cmp::Ordering::Greater
+        core::cmp::Ordering::Greater
     } else {
-        std::cmp::Ordering::Equal
+        core::cmp::Ordering::Equal
     }
 }
 

--- a/src/path64/mod.rs
+++ b/src/path64/mod.rs
@@ -6,6 +6,9 @@
 
 use crate::scalar::{SCALAR_MAX, Scalar};
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 // Must be first, because of macro scope rules.
 #[macro_use] pub mod point64;
 

--- a/src/path64/quad64.rs
+++ b/src/path64/quad64.rs
@@ -6,6 +6,9 @@
 
 use super::Scalar64;
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 pub fn push_valid_ts(s: &[f64], real_roots: usize, t: &mut [f64]) -> usize {
     let mut found_roots = 0;
     'outer: for index in 0..real_roots {

--- a/src/path_builder.rs
+++ b/src/path_builder.rs
@@ -6,6 +6,9 @@
 
 // NOTE: this is not SkPathBuilder, but rather a reimplementation of SkPath.
 
+use alloc::vec;
+use alloc::vec::Vec;
+
 use crate::{Point, Rect, Path};
 
 use crate::path_geometry;

--- a/src/path_geometry.rs
+++ b/src/path_geometry.rs
@@ -13,6 +13,8 @@ use crate::wide::f32x2;
 use crate::path_builder::PathDirection;
 use crate::floating_point::{NormalizedF32, NormalizedF32Exclusive};
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 /// use for : eval(t) == A * t^2 + B * t + C
 #[derive(Default)]

--- a/src/pipeline/highp.rs
+++ b/src/pipeline/highp.rs
@@ -15,8 +15,6 @@ For some reason, we are almost 2x slower. Maybe because Skia uses clang's vector
 and we're using a manual implementation.
 */
 
-use std::ffi::c_void;
-
 use crate::{PremultipliedColorU8, SpreadMode, PixmapMut, PixmapRef};
 
 use crate::geom::ScreenIntRect;
@@ -119,8 +117,8 @@ pub const STAGES: &[StageFn; super::STAGES_COUNT] = &[
     apply_vector_mask,
 ];
 
-pub fn fn_ptr(f: StageFn) -> *const c_void {
-    f as *const () as *const c_void
+pub fn fn_ptr(f: StageFn) -> *const () {
+    f as *const ()
 }
 
 #[inline(never)]

--- a/src/pipeline/lowp.rs
+++ b/src/pipeline/lowp.rs
@@ -26,8 +26,6 @@ And while `-C target-cpu=haswell` boosts our performance by around 25%,
 we are still 40-60% behind Skia built for Haswell.
 */
 
-use std::ffi::c_void;
-
 use crate::{PremultipliedColorU8, PixmapMut};
 
 use crate::geom::ScreenIntRect;
@@ -130,8 +128,8 @@ pub const STAGES: &[StageFn; super::STAGES_COUNT] = &[
     null_fn, // ApplyVectorMask
 ];
 
-pub fn fn_ptr(f: StageFn) -> *const c_void {
-    f as *const () as *const c_void
+pub fn fn_ptr(f: StageFn) -> *const () {
+    f as *const ()
 }
 
 pub fn fn_ptr_eq(f1: StageFn, f2: StageFn) -> bool {

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -44,6 +44,8 @@ There are still some exceptions, which are basically an imperfect implementation
 and should be optimized out in the future.
 */
 
+use alloc::vec::Vec;
+
 use arrayvec::ArrayVec;
 
 use crate::{LengthU32, Color, SpreadMode, PremultipliedColor, PremultipliedColorU8};

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -4,8 +4,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::TryFrom;
-use std::num::NonZeroUsize;
+#[cfg(feature = "png-format")]
+use alloc::string::ToString;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use core::convert::TryFrom;
+use core::num::NonZeroUsize;
 
 use crate::{Color, IntRect};
 
@@ -260,8 +265,8 @@ impl Pixmap {
     }
 }
 
-impl std::fmt::Debug for Pixmap {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for Pixmap {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("Pixmap")
             .field("data", &"...")
             .field("width", &self.size.width())
@@ -423,8 +428,8 @@ impl<'a> PixmapRef<'a> {
     }
 }
 
-impl std::fmt::Debug for PixmapRef<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PixmapRef<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PixmapRef")
             .field("data", &"...")
             .field("width", &self.size.width())
@@ -521,8 +526,8 @@ impl<'a> PixmapMut<'a> {
     }
 }
 
-impl std::fmt::Debug for PixmapMut<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Debug for PixmapMut<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("PixmapMut")
             .field("data", &"...")
             .field("width", &self.size.width())

--- a/src/scalar.rs
+++ b/src/scalar.rs
@@ -67,6 +67,81 @@ impl Scalar for f32 {
     }
 }
 
+cfg_if::cfg_if! {
+    if #[cfg(all(not(feature = "std"), feature = "libm"))] {
+        pub trait FloatExt {
+            fn trunc(self) -> Self;
+            fn sqrt(self) -> Self;
+            fn abs(self) -> Self;
+            fn sin(self) -> Self;
+            fn cos(self) -> Self;
+            fn ceil(self) -> Self;
+            fn floor(self) -> Self;
+            fn powf(self, y: Self) -> Self;
+            fn acos(self) -> Self;
+        }
+
+        impl FloatExt for f32 {
+            fn trunc(self) -> Self {
+                libm::truncf(self)
+            }
+            fn sqrt(self) -> Self {
+                libm::sqrtf(self)
+            }
+            fn abs(self) -> Self {
+                libm::fabsf(self)
+            }
+            fn sin(self) -> Self {
+                libm::sinf(self)
+            }
+            fn cos(self) -> Self {
+                libm::cosf(self)
+            }
+            fn ceil(self) -> Self {
+                libm::ceilf(self)
+            }
+            fn floor(self) -> Self {
+                libm::floorf(self)
+            }
+            fn powf(self, y: Self) -> Self {
+                libm::powf(self, y)
+            }
+            fn acos(self) -> Self {
+                libm::acosf(self)
+            }
+        }
+
+        impl FloatExt for f64 {
+            fn trunc(self) -> Self {
+                libm::trunc(self)
+            }
+            fn sqrt(self) -> Self {
+                libm::sqrt(self)
+            }
+            fn abs(self) -> Self {
+                libm::fabs(self)
+            }
+            fn sin(self) -> Self {
+                libm::sin(self)
+            }
+            fn cos(self) -> Self {
+                libm::cos(self)
+            }
+            fn ceil(self) -> Self {
+                libm::ceil(self)
+            }
+            fn floor(self) -> Self {
+                libm::floor(self)
+            }
+            fn powf(self, y: Self) -> Self {
+                libm::pow(self, y)
+            }
+            fn acos(self) -> Self {
+                libm::acos(self)
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
@@ -74,10 +149,10 @@ mod tests {
 
     #[test]
     fn bound() {
-        assert_eq!(std::f32::NAN.bound(0.0, 1.0), 1.0);
-        assert_eq!(std::f32::INFINITY.bound(0.0, 1.0), 1.0);
-        assert_eq!(std::f32::NEG_INFINITY.bound(0.0, 1.0), 0.0);
-        assert_eq!(std::f32::EPSILON.bound(0.0, 1.0), std::f32::EPSILON);
+        assert_eq!(core::f32::NAN.bound(0.0, 1.0), 1.0);
+        assert_eq!(core::f32::INFINITY.bound(0.0, 1.0), 1.0);
+        assert_eq!(core::f32::NEG_INFINITY.bound(0.0, 1.0), 0.0);
+        assert_eq!(core::f32::EPSILON.bound(0.0, 1.0), core::f32::EPSILON);
         assert_eq!(0.5.bound(0.0, 1.0), 0.5);
         assert_eq!((-1.0).bound(0.0, 1.0), 0.0);
         assert_eq!(2.0.bound(0.0, 1.0), 1.0);

--- a/src/scan/hairline.rs
+++ b/src/scan/hairline.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::TryInto;
+use core::convert::TryInto;
 
 use crate::{Path, LineCap, Point, PathSegment, Rect, IntRect};
 
@@ -18,6 +18,9 @@ use crate::path::PathVerb;
 use crate::path_geometry;
 use crate::scalar::Scalar;
 use crate::wide::f32x2;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 pub type LineProc = fn(&[Point], Option<&ScreenIntRect>, &mut dyn Blitter) -> Option<()>;
 
@@ -78,8 +81,8 @@ fn hair_line_rgn(
 
             if x0 > x1 {
                 // we want to go left-to-right
-                std::mem::swap(&mut x0, &mut x1);
-                std::mem::swap(&mut y0, &mut y1);
+                core::mem::swap(&mut x0, &mut x1);
+                core::mem::swap(&mut y0, &mut y1);
             }
 
             let mut ix0 = fdot6::round(x0);
@@ -110,8 +113,8 @@ fn hair_line_rgn(
 
             if y0 > y1 {
                 // we want to go top-to-bottom
-                std::mem::swap(&mut x0, &mut x1);
-                std::mem::swap(&mut y0, &mut y1);
+                core::mem::swap(&mut x0, &mut x1);
+                core::mem::swap(&mut y0, &mut y1);
             }
 
             let mut iy0 = fdot6::round(y0);

--- a/src/scan/hairline_aa.rs
+++ b/src/scan/hairline_aa.rs
@@ -4,8 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::TryFrom;
-use std::num::NonZeroU16;
+use core::convert::TryFrom;
+use core::num::NonZeroU16;
 
 use crate::{IntRect, LengthU32, Path, LineCap, Point, Rect};
 
@@ -212,7 +212,7 @@ fn call_hline_blitter(
             n = HLINE_STACK_BUFFER as u32;
         }
 
-        debug_assert!(n <= std::u16::MAX as u32);
+        debug_assert!(n <= core::u16::MAX as u32);
         runs[0] = NonZeroU16::new(n as u16);
         runs[n as usize] = None;
         if let Some(y) = y {
@@ -372,8 +372,8 @@ fn do_anti_hairline(
 
         if x0 > x1 {
             // we want to go left-to-right
-            std::mem::swap(&mut x0, &mut x1);
-            std::mem::swap(&mut y0, &mut y1);
+            core::mem::swap(&mut x0, &mut x1);
+            core::mem::swap(&mut y0, &mut y1);
         }
 
         istart = fdot6::floor(x0);
@@ -458,8 +458,8 @@ fn do_anti_hairline(
 
         if y0 > y1 {
             // we want to go top-to-bottom
-            std::mem::swap(&mut x0, &mut x1);
-            std::mem::swap(&mut y0, &mut y1);
+            core::mem::swap(&mut x0, &mut x1);
+            core::mem::swap(&mut y0, &mut y1);
         }
 
         istart = fdot6::floor(y0);
@@ -602,7 +602,7 @@ fn bad_int(x: i32) -> i32 {
 }
 
 fn any_bad_ints(a: i32, b: i32, c: i32, d: i32) -> i32 {
-    (bad_int(a) | bad_int(b) | bad_int(c) | bad_int(d)) >> ((std::mem::size_of::<i32>() << 3) - 1)
+    (bad_int(a) | bad_int(b) | bad_int(c) | bad_int(d)) >> ((core::mem::size_of::<i32>() << 3) - 1)
 }
 
 // We want the fractional part of ordinate, but we want multiples of 64 to

--- a/src/scan/path.rs
+++ b/src/scan/path.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use crate::{Path, IntRect, FillRule, LengthU32, Rect};
 
@@ -14,6 +14,9 @@ use crate::edge_builder::{BasicEdgeBuilder, ShiftedIntRect};
 use crate::fixed_point::{fdot6, fdot16, FDot16};
 use crate::floating_point::SaturateCast;
 use crate::geom::ScreenIntRect;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 pub fn fill_path(
     path: &Path,

--- a/src/scan/path_aa.rs
+++ b/src/scan/path_aa.rs
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 use crate::{Path, IntRect, FillRule, LengthU32, Rect};
 
@@ -13,6 +13,9 @@ use crate::blitter::Blitter;
 use crate::color::AlphaU8;
 use crate::geom::ScreenIntRect;
 use crate::math::left_shift;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 /// controls how much we super-sample (when we use that scan conversion)
 const SUPERSAMPLE_SHIFT: u32 = 2;

--- a/src/shaders/gradient.rs
+++ b/src/shaders/gradient.rs
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use alloc::vec::Vec;
+
 use crate::{Color, Transform, SpreadMode};
 
 use crate::floating_point::NormalizedF32;

--- a/src/shaders/linear_gradient.rs
+++ b/src/shaders/linear_gradient.rs
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use alloc::vec::Vec;
+
 use crate::{Point, Shader, GradientStop, SpreadMode, Transform, Color};
 
 use crate::scalar::Scalar;

--- a/src/shaders/pattern.rs
+++ b/src/shaders/pattern.rs
@@ -10,6 +10,8 @@ use crate::floating_point::NormalizedF32;
 use crate::pipeline;
 use crate::pipeline::RasterPipelineBuilder;
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 /// Controls how much filtering to be done when transforming images.
 #[derive(Copy, Clone, PartialEq, Debug)]
@@ -161,7 +163,7 @@ impl<'a> Pattern<'a> {
 
         // Unlike Skia, we do not support global opacity and only Pattern allows it.
         if self.opacity != NormalizedF32::ONE {
-            debug_assert_eq!(std::mem::size_of_val(&self.opacity), 4, "alpha must be f32");
+            debug_assert_eq!(core::mem::size_of_val(&self.opacity), 4, "alpha must be f32");
             p.ctx.current_coverage = self.opacity.get();
             p.push(pipeline::Stage::Scale1Float);
         }

--- a/src/shaders/radial_gradient.rs
+++ b/src/shaders/radial_gradient.rs
@@ -4,6 +4,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+use alloc::vec::Vec;
+
 use crate::{Point, Shader, GradientStop, SpreadMode, Transform};
 
 use crate::pipeline;
@@ -11,6 +13,9 @@ use crate::scalar::Scalar;
 use crate::wide::u32x8;
 use super::gradient::{Gradient, DEGENERATE_THRESHOLD};
 use crate::pipeline::RasterPipelineBuilder;
+
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 #[derive(Copy, Clone, Debug)]
 struct FocalData {

--- a/src/stroker.rs
+++ b/src/stroker.rs
@@ -13,6 +13,8 @@ use crate::path_builder::PathDirection;
 use crate::path_geometry;
 use crate::scalar::{Scalar, SCALAR_NEARLY_ZERO, SCALAR_ROOT_2_OVER_2};
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 struct SwappableBuilders<'a> {
     inner: &'a mut PathBuilder,
@@ -22,11 +24,11 @@ struct SwappableBuilders<'a> {
 impl<'a> SwappableBuilders<'a> {
     fn swap(&mut self) {
         // Skia swaps pointers to inner and outer builders during joining,
-        // but not builders itself. So a simple `std::mem::swap` will produce invalid results.
-        // And if we try to use use `std::mem::swap` on references, like below,
+        // but not builders itself. So a simple `core::mem::swap` will produce invalid results.
+        // And if we try to use use `core::mem::swap` on references, like below,
         // borrow checker will be unhappy.
         // That's why we need this wrapper. Maybe there is a better solution.
-        std::mem::swap(&mut self.inner, &mut self.outer);
+        core::mem::swap(&mut self.inner, &mut self.outer);
     }
 }
 
@@ -1216,7 +1218,7 @@ impl PathStroker {
 
         // Swap out the outer builder.
         let mut buf = PathBuilder::new();
-        std::mem::swap(&mut self.outer, &mut buf);
+        core::mem::swap(&mut self.outer, &mut buf);
 
         buf.finish()
     }
@@ -1418,7 +1420,7 @@ fn miter_joiner(
         }
 
         handle_inner_join(pivot, after, builders.inner);
-    };
+    }
 
     fn do_miter(builders: SwappableBuilders, pivot: Point, radius: f32,
                 prev_is_line: bool, curr_is_line: bool, mid: Point, after: Point) {
@@ -1429,7 +1431,7 @@ fn miter_joiner(
         }
 
         do_blunt(builders, pivot, radius, curr_is_line, after);
-    };
+    }
 
     // negate the dot since we're using normals instead of tangents
     let dot_prod = before_unit_normal.dot(after_unit_normal);
@@ -1685,7 +1687,7 @@ fn sharp_angle(quad: &[Point; 3]) -> bool {
     let smaller_len = smaller.length_sqd();
     let mut larger_len = larger.length_sqd();
     if smaller_len > larger_len {
-        std::mem::swap(&mut smaller, &mut larger);
+        core::mem::swap(&mut smaller, &mut larger);
         larger_len = smaller_len;
     }
 

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -8,6 +8,8 @@ use crate::Point;
 
 use crate::scalar::{SCALAR_NEARLY_ZERO, Scalar};
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
 
 /// An affine transformation matrix.
 ///

--- a/src/wide/f32x16_t.rs
+++ b/src/wide/f32x16_t.rs
@@ -116,7 +116,7 @@ impl f32x16 {
     }
 }
 
-impl std::ops::Add<f32x16> for f32x16 {
+impl core::ops::Add<f32x16> for f32x16 {
     type Output = Self;
 
     fn add(self, other: f32x16) -> Self::Output {
@@ -127,7 +127,7 @@ impl std::ops::Add<f32x16> for f32x16 {
     }
 }
 
-impl std::ops::Sub<f32x16> for f32x16 {
+impl core::ops::Sub<f32x16> for f32x16 {
     type Output = Self;
 
     fn sub(self, other: f32x16) -> Self::Output {
@@ -138,7 +138,7 @@ impl std::ops::Sub<f32x16> for f32x16 {
     }
 }
 
-impl std::ops::Mul<f32x16> for f32x16 {
+impl core::ops::Mul<f32x16> for f32x16 {
     type Output = Self;
 
     fn mul(self, other: f32x16) -> Self::Output {

--- a/src/wide/f32x2_t.rs
+++ b/src/wide/f32x2_t.rs
@@ -3,6 +3,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 // Right now, there are no visible benefits of using SIMD for f32x2. So we don't.
 #[allow(non_camel_case_types)]
 #[derive(Copy, Clone, Default, PartialEq, Debug)]
@@ -46,7 +49,7 @@ impl f32x2 {
     pub fn y(&self) -> f32 { self.0[1] }
 }
 
-impl std::ops::Add<f32x2> for f32x2 {
+impl core::ops::Add<f32x2> for f32x2 {
     type Output = f32x2;
 
     fn add(self, other: f32x2) -> f32x2 {
@@ -57,7 +60,7 @@ impl std::ops::Add<f32x2> for f32x2 {
     }
 }
 
-impl std::ops::Sub<f32x2> for f32x2 {
+impl core::ops::Sub<f32x2> for f32x2 {
     type Output = f32x2;
 
     fn sub(self, other: f32x2) -> f32x2 {
@@ -68,7 +71,7 @@ impl std::ops::Sub<f32x2> for f32x2 {
     }
 }
 
-impl std::ops::Mul<f32x2> for f32x2 {
+impl core::ops::Mul<f32x2> for f32x2 {
     type Output = f32x2;
 
     fn mul(self, other: f32x2) -> f32x2 {
@@ -79,7 +82,7 @@ impl std::ops::Mul<f32x2> for f32x2 {
     }
 }
 
-impl std::ops::Div<f32x2> for f32x2 {
+impl core::ops::Div<f32x2> for f32x2 {
     type Output = f32x2;
 
     fn div(self, other: f32x2) -> f32x2 {

--- a/src/wide/f32x4_t.rs
+++ b/src/wide/f32x4_t.rs
@@ -6,10 +6,11 @@
 // Based on https://github.com/Lokathor/wide (Zlib)
 
 use bytemuck::cast;
-#[cfg(feature = "simd")] use safe_arch::*;
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "simd", target_feature = "sse"))] {
+        use safe_arch::*;
+
         #[derive(Default, Clone, Copy, PartialEq, Debug)]
         #[repr(C, align(16))]
         pub struct f32x4(m128);
@@ -71,7 +72,7 @@ impl From<f32x4> for [f32; 4] {
     }
 }
 
-impl std::ops::Add for f32x4 {
+impl core::ops::Add for f32x4 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -90,13 +91,13 @@ impl std::ops::Add for f32x4 {
     }
 }
 
-impl std::ops::AddAssign for f32x4 {
+impl core::ops::AddAssign for f32x4 {
     fn add_assign(&mut self, rhs: f32x4) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for f32x4 {
+impl core::ops::Sub for f32x4 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -115,7 +116,7 @@ impl std::ops::Sub for f32x4 {
     }
 }
 
-impl std::ops::Mul for f32x4 {
+impl core::ops::Mul for f32x4 {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -134,7 +135,7 @@ impl std::ops::Mul for f32x4 {
     }
 }
 
-impl std::ops::MulAssign for f32x4 {
+impl core::ops::MulAssign for f32x4 {
     fn mul_assign(&mut self, rhs: f32x4) {
         *self = *self * rhs;
     }

--- a/src/wide/f32x8_t.rs
+++ b/src/wide/f32x8_t.rs
@@ -6,23 +6,26 @@
 // Based on https://github.com/Lokathor/wide (Zlib)
 
 use bytemuck::cast;
-#[cfg(feature = "simd")] use safe_arch::*;
 
 use crate::wide::{u32x8, i32x8};
 
+#[cfg(all(not(feature = "std"), feature = "libm"))]
+use crate::scalar::FloatExt;
+
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "simd", target_feature = "avx"))] {
-        #[cfg(all(feature = "simd", target_feature = "avx"))]
+        use safe_arch::*;
+
         #[derive(Default, Clone, Copy, PartialEq, Debug)]
         #[repr(C, align(32))]
         pub struct f32x8(m256);
     } else if #[cfg(all(feature = "simd", target_feature = "sse2"))] {
-        #[cfg(all(feature = "simd", target_feature = "sse2"))]
+        use safe_arch::*;
+
         #[derive(Default, Clone, Copy, PartialEq, Debug)]
         #[repr(C, align(32))]
         pub struct f32x8(m128, m128);
     } else {
-        #[cfg(not(feature = "simd"))]
         #[derive(Default, Clone, Copy, PartialEq, Debug)]
         #[repr(C, align(32))]
         pub struct f32x8([f32; 8]);
@@ -341,7 +344,7 @@ impl From<f32x8> for [f32; 8] {
     }
 }
 
-impl std::ops::Add for f32x8 {
+impl core::ops::Add for f32x8 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -357,13 +360,13 @@ impl std::ops::Add for f32x8 {
     }
 }
 
-impl std::ops::AddAssign for f32x8 {
+impl core::ops::AddAssign for f32x8 {
     fn add_assign(&mut self, rhs: f32x8) {
         *self = *self + rhs;
     }
 }
 
-impl std::ops::Sub for f32x8 {
+impl core::ops::Sub for f32x8 {
     type Output = Self;
 
     fn sub(self, rhs: Self) -> Self::Output {
@@ -379,7 +382,7 @@ impl std::ops::Sub for f32x8 {
     }
 }
 
-impl std::ops::Mul for f32x8 {
+impl core::ops::Mul for f32x8 {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -395,13 +398,13 @@ impl std::ops::Mul for f32x8 {
     }
 }
 
-impl std::ops::MulAssign for f32x8 {
+impl core::ops::MulAssign for f32x8 {
     fn mul_assign(&mut self, rhs: f32x8) {
         *self = *self * rhs;
     }
 }
 
-impl std::ops::Div for f32x8 {
+impl core::ops::Div for f32x8 {
     type Output = Self;
 
     fn div(self, rhs: Self) -> Self::Output {
@@ -417,7 +420,7 @@ impl std::ops::Div for f32x8 {
     }
 }
 
-impl std::ops::BitAnd for f32x8 {
+impl core::ops::BitAnd for f32x8 {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {
@@ -442,7 +445,7 @@ impl std::ops::BitAnd for f32x8 {
     }
 }
 
-impl std::ops::BitOr for f32x8 {
+impl core::ops::BitOr for f32x8 {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {
@@ -467,7 +470,7 @@ impl std::ops::BitOr for f32x8 {
     }
 }
 
-impl std::ops::BitXor for f32x8 {
+impl core::ops::BitXor for f32x8 {
     type Output = Self;
 
     fn bitxor(self, rhs: Self) -> Self::Output {
@@ -492,7 +495,7 @@ impl std::ops::BitXor for f32x8 {
     }
 }
 
-impl std::ops::Neg for f32x8 {
+impl core::ops::Neg for f32x8 {
     type Output = Self;
 
     fn neg(self) -> Self {
@@ -500,7 +503,7 @@ impl std::ops::Neg for f32x8 {
     }
 }
 
-impl std::ops::Not for f32x8 {
+impl core::ops::Not for f32x8 {
     type Output = Self;
 
     fn not(self) -> Self {

--- a/src/wide/i32x8_t.rs
+++ b/src/wide/i32x8_t.rs
@@ -6,16 +6,19 @@
 // Based on https://github.com/Lokathor/wide (Zlib)
 
 use bytemuck::cast;
-#[cfg(feature = "simd")] use safe_arch::*;
 
 use crate::wide::{f32x8, u32x8};
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "simd", target_feature = "avx2"))] {
+        use safe_arch::*;
+
         #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
         #[repr(C, align(32))]
         pub struct i32x8(m256i);
     } else if #[cfg(all(feature = "simd", target_feature = "sse2"))] {
+        use safe_arch::*;
+
         #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
         #[repr(C, align(32))]
         pub struct i32x8(pub m128i, pub m128i);
@@ -128,7 +131,7 @@ impl From<i32x8> for [i32; 8] {
     }
 }
 
-impl std::ops::Add for i32x8 {
+impl core::ops::Add for i32x8 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -144,7 +147,7 @@ impl std::ops::Add for i32x8 {
     }
 }
 
-impl std::ops::BitAnd for i32x8 {
+impl core::ops::BitAnd for i32x8 {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {
@@ -160,7 +163,7 @@ impl std::ops::BitAnd for i32x8 {
     }
 }
 
-impl std::ops::Mul for i32x8 {
+impl core::ops::Mul for i32x8 {
     type Output = Self;
 
     fn mul(self, rhs: Self) -> Self::Output {
@@ -179,7 +182,7 @@ impl std::ops::Mul for i32x8 {
     }
 }
 
-impl std::ops::BitOr for i32x8 {
+impl core::ops::BitOr for i32x8 {
     type Output = Self;
 
     fn bitor(self, rhs: Self) -> Self::Output {
@@ -195,7 +198,7 @@ impl std::ops::BitOr for i32x8 {
     }
 }
 
-impl std::ops::BitXor for i32x8 {
+impl core::ops::BitXor for i32x8 {
     type Output = Self;
 
     fn bitxor(self, rhs: Self) -> Self::Output {

--- a/src/wide/mod.rs
+++ b/src/wide/mod.rs
@@ -63,7 +63,7 @@ pub use u16x16_t::u16x16;
 #[allow(dead_code)]
 pub fn generic_bit_blend<T>(mask: T, y: T, n: T) -> T
 where
-    T: Copy + std::ops::BitXor<Output = T> + std::ops::BitAnd<Output = T>,
+    T: Copy + core::ops::BitXor<Output = T> + core::ops::BitAnd<Output = T>,
 {
     n ^ ((n ^ y) & mask)
 }

--- a/src/wide/u16x16_t.rs
+++ b/src/wide/u16x16_t.rs
@@ -86,7 +86,7 @@ impl u16x16 {
     }
 }
 
-impl std::ops::Add<u16x16> for u16x16 {
+impl core::ops::Add<u16x16> for u16x16 {
     type Output = Self;
 
     #[inline]
@@ -95,7 +95,7 @@ impl std::ops::Add<u16x16> for u16x16 {
     }
 }
 
-impl std::ops::Sub<u16x16> for u16x16 {
+impl core::ops::Sub<u16x16> for u16x16 {
     type Output = Self;
 
     #[inline]
@@ -104,7 +104,7 @@ impl std::ops::Sub<u16x16> for u16x16 {
     }
 }
 
-impl std::ops::Mul<u16x16> for u16x16 {
+impl core::ops::Mul<u16x16> for u16x16 {
     type Output = Self;
 
     #[inline]
@@ -113,7 +113,7 @@ impl std::ops::Mul<u16x16> for u16x16 {
     }
 }
 
-impl std::ops::Div<u16x16> for u16x16 {
+impl core::ops::Div<u16x16> for u16x16 {
     type Output = Self;
 
     #[inline]
@@ -122,7 +122,7 @@ impl std::ops::Div<u16x16> for u16x16 {
     }
 }
 
-impl std::ops::BitAnd<u16x16> for u16x16 {
+impl core::ops::BitAnd<u16x16> for u16x16 {
     type Output = Self;
 
     #[inline]
@@ -131,7 +131,7 @@ impl std::ops::BitAnd<u16x16> for u16x16 {
     }
 }
 
-impl std::ops::BitOr<u16x16> for u16x16 {
+impl core::ops::BitOr<u16x16> for u16x16 {
     type Output = Self;
 
     #[inline]
@@ -140,7 +140,7 @@ impl std::ops::BitOr<u16x16> for u16x16 {
     }
 }
 
-impl std::ops::Not for u16x16 {
+impl core::ops::Not for u16x16 {
     type Output = Self;
 
     #[inline]

--- a/src/wide/u32x8_t.rs
+++ b/src/wide/u32x8_t.rs
@@ -5,17 +5,20 @@
 
 // Based on https://github.com/Lokathor/wide (Zlib)
 
-#[cfg(feature = "simd")] use bytemuck::cast;
-#[cfg(feature = "simd")] use safe_arch::*;
-
 use crate::wide::{i32x8, f32x8};
 
 cfg_if::cfg_if! {
     if #[cfg(all(feature = "simd", target_feature = "avx2"))] {
+        use safe_arch::*;
+        use bytemuck::cast;
+
         #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
         #[repr(C, align(32))]
         pub struct u32x8(m256i);
     } else if #[cfg(all(feature = "simd", target_feature = "sse2"))] {
+        use safe_arch::*;
+        use bytemuck::cast;
+
         #[derive(Default, Clone, Copy, PartialEq, Eq, Debug)]
         #[repr(C, align(32))]
         pub struct u32x8(m128i, m128i);
@@ -55,7 +58,7 @@ impl u32x8 {
     }
 }
 
-impl std::ops::Not for u32x8 {
+impl core::ops::Not for u32x8 {
     type Output = Self;
 
     fn not(self) -> Self {
@@ -80,7 +83,7 @@ impl std::ops::Not for u32x8 {
     }
 }
 
-impl std::ops::Add for u32x8 {
+impl core::ops::Add for u32x8 {
     type Output = Self;
 
     fn add(self, rhs: Self) -> Self::Output {
@@ -96,7 +99,7 @@ impl std::ops::Add for u32x8 {
     }
 }
 
-impl std::ops::BitAnd for u32x8 {
+impl core::ops::BitAnd for u32x8 {
     type Output = Self;
 
     fn bitand(self, rhs: Self) -> Self::Output {
@@ -112,7 +115,7 @@ impl std::ops::BitAnd for u32x8 {
     }
 }
 
-impl std::ops::Shl<i32> for u32x8 {
+impl core::ops::Shl<i32> for u32x8 {
     type Output = Self;
 
     fn shl(self, rhs: i32) -> Self::Output {
@@ -140,7 +143,7 @@ impl std::ops::Shl<i32> for u32x8 {
     }
 }
 
-impl std::ops::Shr<i32> for u32x8 {
+impl core::ops::Shr<i32> for u32x8 {
     type Output = Self;
 
     fn shr(self, rhs: i32) -> Self::Output {


### PR DESCRIPTION
This brings `no_std` support to tiny-skia. Various floating point functions are not available if you don't target std. For those there is
a new optional `libm` feature that can be used to bring in the `libm` crate's implementations for those functions.