### PR TITLE
Implement Neon SIMD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  x86:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
@@ -77,3 +77,28 @@ jobs:
       env:
         RUSTFLAGS: -Ctarget-feature=+simd128,+bulk-memory,+nontrapping-fptoint,+sign-ext
       run: cargo test --target wasm32-wasi
+
+  aarch64:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Install toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        override: true
+        target: aarch64-unknown-linux-gnu
+
+    - name: Install cross
+      run: cargo install cross
+
+    - name: Build with minimal features (no_std)
+      run: cross build --target aarch64-unknown-linux-gnu --verbose --no-default-features --features no-std-float
+
+    - name: Run tests without SIMD
+      run: cross test --target aarch64-unknown-linux-gnu --verbose --no-default-features --features png-format
+
+    - name: Run tests with Neon
+      run: cross test --target aarch64-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,8 +30,9 @@ default = ["std", "simd", "png-format"]
 std = ["tiny-skia-path/std"]
 no-std-float = ["tiny-skia-path/no-std-float"]
 
-# Enables x86 SIMD instructions from SSE up to AVX2.
-# Has no effect on non-x86 targets. Present mainly for testing.
+# Enables SIMD instructions on x86 (from SSE up to AVX2), WebAssembly (SIMD128)
+# and Aarch64 (Neon).
+# Has no effect other targets. Present mainly for testing.
 simd = []
 
 # Allows loading and saving `Pixmap` as PNG.

--- a/path/src/f32x2_t.rs
+++ b/path/src/f32x2_t.rs
@@ -36,22 +36,22 @@ impl f32x2 {
     /// Returns a minimum value.
     pub fn min(self, other: f32x2) -> f32x2 {
         f32x2([
-            self.x().min(other.x()),
-            self.y().min(other.y()),
+            pmin(self.x(), other.x()),
+            pmin(self.y(), other.y()),
         ])
     }
 
     /// Returns a maximum value.
     pub fn max(self, other: f32x2) -> f32x2 {
         f32x2([
-            self.x().max(other.x()),
-            self.y().max(other.y()),
+            pmax(self.x(), other.x()),
+            pmax(self.y(), other.y()),
         ])
     }
 
     /// Returns a maximum of both values.
     pub fn max_component(self) -> f32 {
-        self.x().max(self.y())
+        pmax(self.x(), self.y())
     }
 
     /// Returns the first value.
@@ -103,4 +103,12 @@ impl core::ops::Div<f32x2> for f32x2 {
             self.y() / other.y(),
         ])
     }
+}
+
+fn pmax(a: f32, b: f32) -> f32 {
+    if a < b { b } else { a }
+}
+
+fn pmin(a: f32, b: f32) -> f32 {
+    if b < a { b } else { a }
 }

--- a/src/pipeline/highp.rs
+++ b/src/pipeline/highp.rs
@@ -416,7 +416,7 @@ blend_fn2!(color_burn, |s: f32x8, d: f32x8, sa: f32x8, da: f32x8|
         d + s * inv(da),
         s.cmp_eq(f32x8::default()).blend(
             d * inv(sa),
-            sa * (da - da.min((da - d) * sa * s.recip())) + s * inv(da) + d * inv(sa)
+            sa * (da - da.min((da - d) * sa * s.recip_fast())) + s * inv(da) + d * inv(sa)
         )
     )
 );
@@ -426,7 +426,7 @@ blend_fn2!(color_dodge, |s: f32x8, d: f32x8, sa: f32x8, da: f32x8|
         s * inv(da),
         s.cmp_eq(sa).blend(
             s + d * inv(sa),
-            sa * da.min((d * sa) * (sa - s).recip()) + s * inv(da) + d * inv(sa)
+            sa * da.min((d * sa) * (sa - s).recip_fast()) + s * inv(da) + d * inv(sa)
         )
     )
 );
@@ -456,7 +456,7 @@ blend_fn2!(soft_light, |s: f32x8, d: f32x8, sa: f32x8, da: f32x8| {
     //    3. light src, light dst?
     let dark_src = d * (sa + (s2 - sa) * (f32x8::splat(1.0) - m));
     let dark_dst = (m4 * m4 + m4) * (m - f32x8::splat(1.0)) + f32x8::splat(7.0) * m;
-    let lite_dst = m.recip_sqrt().recip() - m;
+    let lite_dst = m.sqrt() - m;
     let lite_src = d * sa + da * (s2 - sa)
         * two(two(d)).cmp_le(da).blend(dark_dst, lite_dst); // 2 or 3?
 

--- a/src/wide/f32x16_t.rs
+++ b/src/wide/f32x16_t.rs
@@ -74,7 +74,7 @@ impl f32x16 {
 
     pub fn floor(&self) -> Self {
         // Yes, Skia does it in the same way.
-        let roundtrip = self.round_int();
+        let roundtrip = self.round();
         roundtrip - roundtrip.cmp_gt(self).blend(f32x16::splat(1.0), f32x16::splat(0.0))
     }
 
@@ -85,10 +85,10 @@ impl f32x16 {
         ])
     }
 
-    pub fn round_int(&self) -> Self {
+    pub fn round(&self) -> Self {
         Self([
-            self.0[0].round_int().to_f32x8(),
-            self.0[1].round_int().to_f32x8(),
+            self.0[0].round(),
+            self.0[1].round(),
         ])
     }
 

--- a/src/wide/mod.rs
+++ b/src/wide/mod.rs
@@ -60,6 +60,16 @@ pub use f32x16_t::f32x16;
 pub use u16x16_t::u16x16;
 
 #[allow(dead_code)]
+fn pmax(a: f32, b: f32) -> f32 {
+    if a < b { b } else { a }
+}
+
+#[allow(dead_code)]
+fn pmin(a: f32, b: f32) -> f32 {
+    if b < a { b } else { a }
+}
+
+#[allow(dead_code)]
 #[inline]
 pub fn generic_bit_blend<T>(mask: T, y: T, n: T) -> T
 where


### PR DESCRIPTION
This adds support for the NEON SIMD instructions. They are still nightly only and some instructions are missing, but they are close to finishing implementing all of them, so stabilization shouldn't be too far off. There's a few semantic differences between the different targets which leaves some open questions in the meantime.