### PR TITLE
Remove unwrap in Rect::round_out

### DIFF
--- a/src/geom.rs
+++ b/src/geom.rs
@@ -790,25 +790,25 @@ impl Rect {
     /// Converts into an `IntRect` by adding 0.5 and discarding the fractional portion.
     ///
     /// Width and height are guarantee to be >= 1.
-    pub fn round(&self) -> IntRect {
+    pub fn round(&self) -> Option<IntRect> {
         IntRect::from_xywh(
             i32::saturate_round(self.x()),
             i32::saturate_round(self.y()),
             core::cmp::max(1, i32::saturate_round(self.width()) as u32),
             core::cmp::max(1, i32::saturate_round(self.height()) as u32),
-        ).unwrap()
+        )
     }
 
     /// Converts into an `IntRect` rounding outwards.
     ///
     /// Width and height are guarantee to be >= 1.
-    pub(crate) fn round_out(&self) -> IntRect {
+    pub(crate) fn round_out(&self) -> Option<IntRect> {
         IntRect::from_xywh(
             i32::saturate_floor(self.x()),
             i32::saturate_floor(self.y()),
             core::cmp::max(1, i32::saturate_ceil(self.width()) as u32),
             core::cmp::max(1, i32::saturate_ceil(self.height()) as u32),
-        ).unwrap()
+        )
     }
 
     /// Returns an intersection of two rectangles.
@@ -928,5 +928,18 @@ mod rect_tests {
         let rect = Rect::from_ltrb(-30.0, 20.0, -10.0, 40.0).unwrap();
         assert_eq!(rect.width(), 20.0);
         assert_eq!(rect.height(), 20.0);
+    }
+
+    #[test]
+    fn round_overflow() {
+        // minimum value that cause overflow
+        // because i32::MAX has no exact conversion to f32
+        let x = 128.0;
+        // maximum width
+        let width = i32::MAX as f32;
+
+        let rect = Rect::from_xywh(x, 0.0, width, 1.0).unwrap();
+        assert_eq!(rect.round(), None);
+        assert_eq!(rect.round_out(), None);
     }
 }

--- a/src/scan/hairline.rs
+++ b/src/scan/hairline.rs
@@ -170,7 +170,7 @@ pub fn stroke_path_impl(
 
     {
         let cap_out = if line_cap == LineCap::Butt { 1.0 } else { 2.0 };
-        let ibounds = path.bounds().outset(cap_out, cap_out)?.round_out();
+        let ibounds = path.bounds().outset(cap_out, cap_out)?.round_out()?;
         clip.to_int_rect().intersect(&ibounds)?;
 
         if !clip.to_int_rect().contains(&ibounds) {

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -21,7 +21,7 @@ pub fn fill_rect(
     clip: &ScreenIntRect,
     blitter: &mut dyn Blitter,
 ) -> Option<()> {
-    fill_int_rect(&rect.round(), clip, blitter)
+    fill_int_rect(&rect.round()?, clip, blitter)
 }
 
 fn fill_int_rect(

--- a/src/scan/path_aa.rs
+++ b/src/scan/path_aa.rs
@@ -37,7 +37,7 @@ pub fn fill_path(
         path.bounds.top().floor(),
         path.bounds.right().ceil(),
         path.bounds.bottom().ceil(),
-    )?.round_out();
+    )?.round_out()?;
 
     // If the intersection of the path bounds and the clip bounds
     // will overflow 32767 when << by SHIFT, we can't supersample,


### PR DESCRIPTION
fix #49 

Removed unwrap and return an option.