### PR TITLE
Fix missed name change in tiny-skia-path

### DIFF
--- a/path/LICENSE
+++ b/path/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2011 Google Inc. All rights reserved.
-Copyright (c) 2020 Reizner Evgeniy All rights reserved.
+Copyright (c) 2020 Yevhenii Reizner All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are


### PR DESCRIPTION
Looks like this was missed when splitting path out to its own crate.

This got noticed during license review for Debian packaging.
