### PR TITLE
Remove save_png() call in stroke test

### DIFF
--- a/tests/integration/stroke.rs
+++ b/tests/integration/stroke.rs
@@ -61,8 +61,6 @@ fn zero_len_subpath_butt_cap() {
     let mut pixmap = Pixmap::new(100, 100).unwrap();
     pixmap.stroke_path(&path, &paint, &stroke, Transform::default(), None);
 
-    pixmap.save_png("tests/images/stroke/zero-len-subpath-butt-cap.png").unwrap();
-
     let expected = Pixmap::load_png("tests/images/stroke/zero-len-subpath-butt-cap.png").unwrap();
     assert_eq!(pixmap, expected);
 }


### PR DESCRIPTION
The test is supposed to generate the pixmap in memory and then compare
it to what's present in tests/images/.  However, it's first overwriting
the "expected" file, likely left over from generating the expected data
in the first place.
