### PR TITLE
perf(pipeline::lowp::div255)

### DIFF
--- a/src/pipeline/lowp.rs
+++ b/src/pipeline/lowp.rs
@@ -743,7 +743,8 @@ fn store_8888_tail(
 fn div255(v: u16x16) -> u16x16 {
     // Skia uses `vrshrq_n_u16(vrsraq_n_u16(v, v, 8), 8)` here when NEON is available,
     // but it doesn't affect performance much and breaks reproducible result. Ignore it.
-    (v + u16x16::splat(255)) / u16x16::splat(256)
+    // NOTE: the compiler does not replace the devision with a shift.
+    (v + u16x16::splat(255)) >> u16x16::splat(8) // / u16x16::splat(256)
 }
 
 #[inline(always)]

--- a/src/wide/u16x16_t.rs
+++ b/src/wide/u16x16_t.rs
@@ -239,3 +239,12 @@ impl core::ops::Not for u16x16 {
         ])
     }
 }
+
+impl core::ops::Shr for u16x16 {
+    type Output = Self;
+
+    #[inline]
+    fn shr(self, rhs: Self) -> Self::Output {
+        impl_u16x16_op!(self, shr, rhs)
+    }
+}


### PR DESCRIPTION
This significantly improves performance of clipping (on my machine, clipping benchmarks are about 4 times faster).