### PR TITLE
Fix test failures on big endian targets

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,3 +106,6 @@ jobs:
 
     - name: Run tests with Neon
       run: cross test --target aarch64-unknown-linux-gnu
+
+    - name: Rust tests on PowerPC (big endian)
+      run: cross test --target powerpc-unknown-linux-gnu

--- a/src/color.rs
+++ b/src/color.rs
@@ -36,22 +36,22 @@ impl ColorU8 {
 
     /// Returns color's red component.
     pub const fn red(self) -> u8 {
-        ((self.0 >> 0) & 0xFF) as u8
+        self.0.to_ne_bytes()[0]
     }
 
     /// Returns color's green component.
     pub const fn green(self) -> u8 {
-        ((self.0 >> 8) & 0xFF) as u8
+        self.0.to_ne_bytes()[1]
     }
 
     /// Returns color's blue component.
     pub const fn blue(self) -> u8 {
-        ((self.0 >> 16) & 0xFF) as u8
+        self.0.to_ne_bytes()[2]
     }
 
     /// Returns color's alpha component.
     pub const fn alpha(self) -> u8 {
-        ((self.0 >> 24) & 0xFF) as u8
+        self.0.to_ne_bytes()[3]
     }
 
     /// Check that color is opaque.
@@ -128,26 +128,26 @@ impl PremultipliedColorU8 {
     ///
     /// The value is <= alpha.
     pub const fn red(self) -> u8 {
-        ((self.0 >> 0) & 0xFF) as u8
+        self.0.to_ne_bytes()[0]
     }
 
     /// Returns color's green component.
     ///
     /// The value is <= alpha.
     pub const fn green(self) -> u8 {
-        ((self.0 >> 8) & 0xFF) as u8
+        self.0.to_ne_bytes()[1]
     }
 
     /// Returns color's blue component.
     ///
     /// The value is <= alpha.
     pub const fn blue(self) -> u8 {
-        ((self.0 >> 16) & 0xFF) as u8
+        self.0.to_ne_bytes()[2]
     }
 
     /// Returns color's alpha component.
     pub const fn alpha(self) -> u8 {
-        ((self.0 >> 24) & 0xFF) as u8
+        self.0.to_ne_bytes()[3]
     }
 
     /// Check that color is opaque.
@@ -427,7 +427,7 @@ pub fn premultiply_u8(c: u8, a: u8) -> u8 {
 }
 
 const fn pack_rgba(r: u8, g: u8, b: u8, a: u8) -> u32 {
-    ((a as u32) << 24) | ((b as u32) << 16) | ((g as u32) << 8) | ((r as u32) << 0)
+    u32::from_ne_bytes([r, g, b, a])
 }
 
 fn color_f32_to_u8(


### PR DESCRIPTION
Tested with `cross test --target powerpc-unknown-linux-gnu`. Fixes https://github.com/RazrFalcon/tiny-skia/issues/68. I have not tested on a big endian system / emulator beyond running these tests.