### PR TITLE
Implement `PartialEq` for `Paint` and subtypes

### DIFF
--- a/src/painter.rs
+++ b/src/painter.rs
@@ -31,7 +31,7 @@ impl Default for FillRule {
 }
 
 /// Controls how a shape should be painted.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Paint<'a> {
     /// A paint shader.
     ///

--- a/src/shaders/gradient.rs
+++ b/src/shaders/gradient.rs
@@ -37,7 +37,7 @@ impl GradientStop {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Gradient {
     stops: Vec<GradientStop>,
     tile_mode: SpreadMode,

--- a/src/shaders/linear_gradient.rs
+++ b/src/shaders/linear_gradient.rs
@@ -14,7 +14,7 @@ use super::gradient::{Gradient, DEGENERATE_THRESHOLD};
 use crate::pipeline::RasterPipelineBuilder;
 
 /// A linear gradient shader.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct LinearGradient {
     pub(crate) base: Gradient,
 }

--- a/src/shaders/mod.rs
+++ b/src/shaders/mod.rs
@@ -49,7 +49,7 @@ impl Default for SpreadMode {
 /// once (e.g. bitmap tiling or gradient) and then change its transparency
 /// without having to modify the original shader. Only the paint's alpha needs
 /// to be modified.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub enum Shader<'a> {
     /// A solid color shader.
     SolidColor(Color),

--- a/src/shaders/pattern.rs
+++ b/src/shaders/pattern.rs
@@ -28,7 +28,7 @@ pub enum FilterQuality {
 /// Controls how a pixmap should be blended.
 ///
 /// Like `Paint`, but for `Pixmap`.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 pub struct PixmapPaint {
     /// Pixmap opacity.
     ///
@@ -64,7 +64,7 @@ impl Default for PixmapPaint {
 ///
 /// Unlike Skia, we do not support FilterQuality::Medium, because it involves
 /// mipmap generation, which adds too much complexity.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct Pattern<'a> {
     pub(crate) pixmap: PixmapRef<'a>,
     quality: FilterQuality,

--- a/src/shaders/radial_gradient.rs
+++ b/src/shaders/radial_gradient.rs
@@ -18,7 +18,7 @@ use crate::wide::u32x8;
 #[cfg(all(not(feature = "std"), feature = "no-std-float"))]
 use tiny_skia_path::NoStdFloat;
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, PartialEq, Debug)]
 struct FocalData {
     r1: f32, // r1 after mapping focal point to (0, 0)
 }
@@ -43,7 +43,7 @@ impl FocalData {
 ///
 /// This is not `SkRadialGradient` like in Skia, but rather `SkTwoPointConicalGradient`
 /// without the start radius.
-#[derive(Clone, Debug)]
+#[derive(Clone, PartialEq, Debug)]
 pub struct RadialGradient {
     pub(crate) base: Gradient,
     focal_data: Option<FocalData>,


### PR DESCRIPTION
I'm experimenting with diffing and incremental rendering in `iced` with `tiny-skia` and I need to be able to compare `Paint` types.