### PR TITLE
Change Rect::inset and outset to take shared reference

### DIFF
--- a/path/src/rect.rs
+++ b/path/src/rect.rs
@@ -395,7 +395,7 @@ impl Rect {
     }
 
     /// Insets the rectangle by the specified offset.
-    pub fn inset(&mut self, dx: f32, dy: f32) -> Option<Self> {
+    pub fn inset(&self, dx: f32, dy: f32) -> Option<Self> {
         Rect::from_ltrb(
             self.left() + dx,
             self.top() + dy,
@@ -405,7 +405,7 @@ impl Rect {
     }
 
     /// Outsets the rectangle by the specified offset.
-    pub fn outset(&mut self, dx: f32, dy: f32) -> Option<Self> {
+    pub fn outset(&self, dx: f32, dy: f32) -> Option<Self> {
         self.inset(-dx, -dy)
     }
 


### PR DESCRIPTION
These two methods were taking a mutable reference but they don't mutate self and construct a new value so I think it makes more sense for them to just borrow self.