### PR TITLE
stroker: Don't switch line_join from MiterClip to Bevel with miter_limit <= 1.0

### DIFF
--- a/path/src/stroker.rs
+++ b/path/src/stroker.rs
@@ -331,12 +331,16 @@ impl PathStroker {
 
         let mut inv_miter_limit = 0.0;
 
-        if line_join == LineJoin::Miter || line_join == LineJoin::MiterClip {
+        if line_join == LineJoin::Miter {
             if miter_limit <= 1.0 {
                 line_join = LineJoin::Bevel;
             } else {
                 inv_miter_limit = miter_limit.invert();
             }
+        }
+
+        if line_join == LineJoin::MiterClip {
+            inv_miter_limit = miter_limit.invert();
         }
 
         self.res_scale = res_scale;


### PR DESCRIPTION
Really sorry for the trouble again, I saw you just recently released and published 0.11.0...

As it turns out, one simple change that I did right before submitting #91, actually broke my "nearly perfect" results when comparing to Flash Player - which was the main reason I implemented `MiterClip` in the first place...

So this PR restores it to the state where the match with FP is actually nearly perfect.

Since this time it should really only accept `MiterClip`, I hope you will accept it.