### PR TITLE
Directly use associated constants on numeric types

### DIFF
--- a/path/src/floating_point.rs
+++ b/path/src/floating_point.rs
@@ -129,7 +129,7 @@ impl NormalizedF32Exclusive {
     ///
     /// Returns zero in case of NaN or infinity.
     pub fn new_bounded(n: f32) -> Self {
-        let n = n.bound(core::f32::EPSILON, 1.0 - core::f32::EPSILON);
+        let n = n.bound(f32::EPSILON, 1.0 - f32::EPSILON);
         // `n` is guarantee to be finite after clamping.
         debug_assert!(n.is_finite());
         NormalizedF32Exclusive(unsafe { FiniteF32::new_unchecked(n) })

--- a/path/src/rect.rs
+++ b/path/src/rect.rs
@@ -171,14 +171,14 @@ mod int_rect_tests {
         assert_eq!(IntRect::from_xywh(0, 0, 0, 1), None);
 
         assert_eq!(
-            IntRect::from_xywh(0, 0, core::u32::MAX, core::u32::MAX),
+            IntRect::from_xywh(0, 0, u32::MAX, u32::MAX),
             None
         );
-        assert_eq!(IntRect::from_xywh(0, 0, 1, core::u32::MAX), None);
-        assert_eq!(IntRect::from_xywh(0, 0, core::u32::MAX, 1), None);
+        assert_eq!(IntRect::from_xywh(0, 0, 1, u32::MAX), None);
+        assert_eq!(IntRect::from_xywh(0, 0, u32::MAX, 1), None);
 
-        assert_eq!(IntRect::from_xywh(core::i32::MAX, 0, 1, 1), None);
-        assert_eq!(IntRect::from_xywh(0, core::i32::MAX, 1, 1), None);
+        assert_eq!(IntRect::from_xywh(i32::MAX, 0, 1, 1), None);
+        assert_eq!(IntRect::from_xywh(0, i32::MAX, 1, 1), None);
 
         {
             // No intersection.
@@ -444,7 +444,7 @@ fn checked_f32_sub(a: f32, b: f32) -> Option<f32> {
 
     let n = a as f64 - b as f64;
     // Not sure if this is perfectly correct.
-    if n > core::f32::MIN as f64 && n < core::f32::MAX as f64 {
+    if n > f32::MIN as f64 && n < f32::MAX as f64 {
         Some(n as f32)
     } else {
         None
@@ -459,11 +459,11 @@ mod rect_tests {
     fn tests() {
         assert_eq!(Rect::from_ltrb(10.0, 10.0, 5.0, 10.0), None);
         assert_eq!(Rect::from_ltrb(10.0, 10.0, 10.0, 5.0), None);
-        assert_eq!(Rect::from_ltrb(core::f32::NAN, 10.0, 10.0, 10.0), None);
-        assert_eq!(Rect::from_ltrb(10.0, core::f32::NAN, 10.0, 10.0), None);
-        assert_eq!(Rect::from_ltrb(10.0, 10.0, core::f32::NAN, 10.0), None);
-        assert_eq!(Rect::from_ltrb(10.0, 10.0, 10.0, core::f32::NAN), None);
-        assert_eq!(Rect::from_ltrb(10.0, 10.0, 10.0, core::f32::INFINITY), None);
+        assert_eq!(Rect::from_ltrb(f32::NAN, 10.0, 10.0, 10.0), None);
+        assert_eq!(Rect::from_ltrb(10.0, f32::NAN, 10.0, 10.0), None);
+        assert_eq!(Rect::from_ltrb(10.0, 10.0, f32::NAN, 10.0), None);
+        assert_eq!(Rect::from_ltrb(10.0, 10.0, 10.0, f32::NAN), None);
+        assert_eq!(Rect::from_ltrb(10.0, 10.0, 10.0, f32::INFINITY), None);
 
         let rect = Rect::from_ltrb(10.0, 20.0, 30.0, 40.0).unwrap();
         assert_eq!(rect.left(), 10.0);

--- a/path/src/scalar.rs
+++ b/path/src/scalar.rs
@@ -164,10 +164,10 @@ mod tests {
 
     #[test]
     fn bound() {
-        assert_eq!(core::f32::NAN.bound(0.0, 1.0), 1.0);
-        assert_eq!(core::f32::INFINITY.bound(0.0, 1.0), 1.0);
-        assert_eq!(core::f32::NEG_INFINITY.bound(0.0, 1.0), 0.0);
-        assert_eq!(core::f32::EPSILON.bound(0.0, 1.0), core::f32::EPSILON);
+        assert_eq!(f32::NAN.bound(0.0, 1.0), 1.0);
+        assert_eq!(f32::INFINITY.bound(0.0, 1.0), 1.0);
+        assert_eq!(f32::NEG_INFINITY.bound(0.0, 1.0), 0.0);
+        assert_eq!(f32::EPSILON.bound(0.0, 1.0), f32::EPSILON);
         assert_eq!(0.5.bound(0.0, 1.0), 0.5);
         assert_eq!((-1.0).bound(0.0, 1.0), 0.0);
         assert_eq!(2.0.bound(0.0, 1.0), 1.0);

--- a/src/fixed_point.rs
+++ b/src/fixed_point.rs
@@ -63,7 +63,7 @@ pub mod fdot6 {
     }
 
     pub fn can_convert_to_fdot16(n: FDot6) -> bool {
-        let max_dot6 = core::i32::MAX >> (16 - 6);
+        let max_dot6 = i32::MAX >> (16 - 6);
         n.abs() <= max_dot6
     }
 

--- a/src/geom.rs
+++ b/src/geom.rs
@@ -159,21 +159,21 @@ mod screen_int_rect_tests {
         assert_eq!(ScreenIntRect::from_xywh(0, 0, 0, 1), None);
 
         assert_eq!(
-            ScreenIntRect::from_xywh(0, 0, core::u32::MAX, core::u32::MAX),
+            ScreenIntRect::from_xywh(0, 0, u32::MAX, u32::MAX),
             None
         );
-        assert_eq!(ScreenIntRect::from_xywh(0, 0, 1, core::u32::MAX), None);
-        assert_eq!(ScreenIntRect::from_xywh(0, 0, core::u32::MAX, 1), None);
+        assert_eq!(ScreenIntRect::from_xywh(0, 0, 1, u32::MAX), None);
+        assert_eq!(ScreenIntRect::from_xywh(0, 0, u32::MAX, 1), None);
 
-        assert_eq!(ScreenIntRect::from_xywh(core::u32::MAX, 0, 1, 1), None);
-        assert_eq!(ScreenIntRect::from_xywh(0, core::u32::MAX, 1, 1), None);
+        assert_eq!(ScreenIntRect::from_xywh(u32::MAX, 0, 1, 1), None);
+        assert_eq!(ScreenIntRect::from_xywh(0, u32::MAX, 1, 1), None);
 
         assert_eq!(
             ScreenIntRect::from_xywh(
-                core::u32::MAX,
-                core::u32::MAX,
-                core::u32::MAX,
-                core::u32::MAX
+                u32::MAX,
+                u32::MAX,
+                u32::MAX,
+                u32::MAX
             ),
             None
         );

--- a/src/scan/hairline_aa.rs
+++ b/src/scan/hairline_aa.rs
@@ -209,7 +209,7 @@ fn call_hline_blitter(
             n = HLINE_STACK_BUFFER as u32;
         }
 
-        debug_assert!(n <= core::u16::MAX as u32);
+        debug_assert!(n <= u16::MAX as u32);
         runs[0] = NonZeroU16::new(n as u16);
         runs[n as usize] = None;
         if let Some(y) = y {


### PR DESCRIPTION
`u32::MAX`, `f32::EPSILON`, etc. are all available directly on their type, there is no need to use the soon-to-be deprecated `core::*` modules for those.