### PR TITLE
clippy: Remove unnecessary casts.

### DIFF
--- a/path/src/dash.rs
+++ b/path/src/dash.rs
@@ -212,7 +212,7 @@ fn dash_impl(src: &Path, dash: &StrokeDash, res_scale: f32) -> Option<Path> {
             added_segment = false;
             if is_even(index) && !skip_first_segment {
                 added_segment = true;
-                contour.push_segment(distance as f32, (distance + d_len) as f32, true, &mut pb);
+                contour.push_segment(distance, distance + d_len, true, &mut pb);
             }
 
             distance += d_len;

--- a/src/alpha_runs.rs
+++ b/src/alpha_runs.rs
@@ -144,7 +144,7 @@ impl AlphaRuns {
                 1,
             );
             alpha_offset += x;
-            self.alpha[alpha_offset] = (self.alpha[alpha_offset] + stop_alpha) as u8;
+            self.alpha[alpha_offset] += stop_alpha;
             last_alpha_offset = alpha_offset;
         }
 

--- a/src/edge.rs
+++ b/src/edge.rs
@@ -307,7 +307,7 @@ impl QuadraticEdge {
         self.qy = newy;
         self.qdx = dx;
         self.qdy = dy;
-        self.curve_count = count as i8;
+        self.curve_count = count;
 
         success
     }

--- a/src/scan/path.rs
+++ b/src/scan/path.rs
@@ -170,8 +170,8 @@ pub fn fill_path_impl(
     }
 
     let bottom = shifted_clip.shifted().bottom() as i32;
-    if !path_contained_in_clip && stop_y > bottom as i32 {
-        stop_y = bottom as i32;
+    if !path_contained_in_clip && stop_y > bottom {
+        stop_y = bottom;
     }
 
     let start_y = match u32::try_from(start_y) {


### PR DESCRIPTION
In `alpha_runs.rs`, this also let us use `+=` to prevent another clippy warning.