### PR TITLE
Fix rounding error in non-AA curve edge smoothing

### DIFF
--- a/src/edge.rs
+++ b/src/edge.rs
@@ -512,7 +512,7 @@ fn diff_to_shift(dx: FDot6, dy: FDot6, shift_aa: i32) -> i32 {
     // ... but small enough so that our curves still look smooth
     // When shift > 0, we're using AA and everything is scaled up so we can
     // lower the accuracy.
-    dist = (dist + (1 << 4)) >> (3 + shift_aa);
+    dist = (dist + (1 << (2 + shift_aa))) >> (3 + shift_aa);
 
     // each subdivision (shift value) cuts this dist (error) by 1/4
     (32 - dist.leading_zeros() as i32) >> 1


### PR DESCRIPTION
This change ensures precise rounding to the nearest 1/8 pixel by adding 1/16 pixel (in dot6 format) before the shift operation in cases where 'shiftAA' is 0. See http://review.skia.org/820656 for details.