### PR TITLE
Remove implicit `png` feature, only have `png-format`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,4 +37,4 @@ no-std-float = ["tiny-skia-path/no-std-float"]
 simd = []
 
 # Allows loading and saving `Pixmap` as PNG.
-png-format = ["std", "png"]
+png-format = ["std", "dep:png"]


### PR DESCRIPTION
The optional `png` dependency creates an implicit `png` feature which shows up when you do a `cargo add tiny-skia` but that won't do anything when enabled. The right feature to enable is `png-format` so we only need to have that one.