### PR TITLE
Add reborrowing PixmapMut::as_mut

### DIFF
--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -332,6 +332,11 @@ impl<'a> PixmapRef<'a> {
         }
     }
 
+    /// Reborrows the current container
+    pub fn as_ref(&self) -> Self {
+        *self
+    }
+
     /// Returns pixmap's width.
     #[inline]
     pub fn width(&self) -> u32 {
@@ -484,6 +489,14 @@ impl<'a> PixmapMut<'a> {
     /// Returns a container that references Pixmap's data.
     pub fn as_ref(&self) -> PixmapRef<'_> {
         PixmapRef {
+            data: self.data,
+            size: self.size,
+        }
+    }
+
+    /// Reborrows the current container
+    pub fn as_mut<'b: 'a>(&'b mut self) -> PixmapMut<'b> {
+        Self {
             data: self.data,
             size: self.size,
         }


### PR DESCRIPTION
This allows you to get `PixmapMut`s all the way down, which can simplify structs and function signatures.

This also adds `PixmapRef::as_ref` for parity, which is just a `Copy` alias.