### PR TITLE
Avoid oom situations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Cargo.lock
 .DS_Store
 /image.png
 /.vscode
+/.idea

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -192,7 +192,10 @@ impl Mask {
         let output_buffer_size = reader
             .output_buffer_size()
             .ok_or(png::DecodingError::LimitsExceeded)?;
-        let mut img_data = vec![0; output_buffer_size];
+        let mut img_data = Vec::new();
+        img_data
+            .try_reserve_exact(output_buffer_size)
+            .map_err(|_| make_custom_png_error("failed to reserve output buffer"))?;
         let info = reader.next_frame(&mut img_data)?;
 
         if info.bit_depth != png::BitDepth::Eight {

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -44,13 +44,11 @@ impl Pixmap {
         let size = IntSize::from_wh(width, height)?;
         let data_len = data_len_for_size(size)?;
 
-        // We cannot check that allocation was successful yet.
-        // We have to wait for https://github.com/rust-lang/rust/issues/48043
+        let mut data = Vec::new();
+        data.try_reserve_exact(data_len).ok()?;
+        data.resize(data_len, 0);
 
-        Some(Pixmap {
-            data: vec![0; data_len],
-            size,
-        })
+        Some(Pixmap { data, size })
     }
 
     /// Creates a new pixmap by taking ownership over an image buffer


### PR DESCRIPTION
Should help with https://github.com/linebender/resvg/issues/852

Also updated ubuntu image to restoreCI for aarch64 and wasm