### PR TITLE
Remove warnings from Rust 1.89.0

### DIFF
--- a/path/src/path.rs
+++ b/path/src/path.rs
@@ -140,7 +140,7 @@ impl Path {
     }
 
     /// Returns an iterator over path's segments.
-    pub fn segments(&self) -> PathSegmentsIter {
+    pub fn segments(&self) -> PathSegmentsIter<'_> {
         PathSegmentsIter {
             path: self,
             verb_index: 0,

--- a/path/src/stroker.rs
+++ b/path/src/stroker.rs
@@ -426,7 +426,7 @@ impl PathStroker {
         self.finish(last_segment_is_line)
     }
 
-    fn builders(&mut self) -> SwappableBuilders {
+    fn builders(&mut self) -> SwappableBuilders<'_> {
         SwappableBuilders {
             inner: &mut self.inner,
             outer: &mut self.outer,

--- a/src/edge_builder.rs
+++ b/src/edge_builder.rs
@@ -241,7 +241,7 @@ fn combine_vertical(edge: &LineEdge, last: &mut LineEdge) -> Combine {
     Combine::No
 }
 
-pub fn edge_iter(path: &Path) -> PathEdgeIter {
+pub fn edge_iter(path: &Path) -> PathEdgeIter<'_> {
     PathEdgeIter {
         path,
         verb_index: 0,

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -180,7 +180,7 @@ impl Pixmap {
     }
 
     /// Returns a container that references Pixmap's data.
-    pub fn as_ref(&self) -> PixmapRef {
+    pub fn as_ref(&self) -> PixmapRef<'_> {
         PixmapRef {
             data: &self.data,
             size: self.size,
@@ -188,7 +188,7 @@ impl Pixmap {
     }
 
     /// Returns a container that references Pixmap's data.
-    pub fn as_mut(&mut self) -> PixmapMut {
+    pub fn as_mut(&mut self) -> PixmapMut<'_> {
         PixmapMut {
             data: &mut self.data,
             size: self.size,
@@ -482,7 +482,7 @@ impl<'a> PixmapMut<'a> {
     }
 
     /// Returns a container that references Pixmap's data.
-    pub fn as_ref(&self) -> PixmapRef {
+    pub fn as_ref(&self) -> PixmapRef<'_> {
         PixmapRef {
             data: self.data,
             size: self.size,
@@ -527,7 +527,7 @@ impl<'a> PixmapMut<'a> {
     }
 
     /// Creates `SubPixmapMut` that contains the whole `PixmapMut`.
-    pub(crate) fn as_subpixmap(&mut self) -> SubPixmapMut {
+    pub(crate) fn as_subpixmap(&mut self) -> SubPixmapMut<'_> {
         SubPixmapMut {
             size: self.size(),
             real_width: self.width() as usize,
@@ -538,7 +538,7 @@ impl<'a> PixmapMut<'a> {
     /// Returns a mutable reference to the pixmap region that intersects the `rect`.
     ///
     /// Returns `None` when `Pixmap`'s rect doesn't contain `rect`.
-    pub(crate) fn subpixmap(&mut self, rect: IntRect) -> Option<SubPixmapMut> {
+    pub(crate) fn subpixmap(&mut self, rect: IntRect) -> Option<SubPixmapMut<'_>> {
         let rect = self.size.to_int_rect(0, 0).intersect(&rect)?;
         let row_bytes = self.width() as usize * BYTES_PER_PIXEL;
         let offset = rect.top() as usize * row_bytes + rect.left() as usize * BYTES_PER_PIXEL;

--- a/src/wide/mod.rs
+++ b/src/wide/mod.rs
@@ -29,6 +29,7 @@ pub use f32x4_t::f32x4;
 pub use f32x8_t::f32x8;
 pub use i32x4_t::i32x4;
 pub use i32x8_t::i32x8;
+#[allow(unused_imports)]
 pub use tiny_skia_path::f32x2;
 pub use u16x16_t::u16x16;
 pub use u32x4_t::u32x4;


### PR DESCRIPTION
Rust 1.89.0 (release Aug. 7th) introduces many warnings related to elided lifetimes.
This PR amends the code to satisfy the compiler.