### PR TITLE
Add `Mask::take` method

### DIFF
--- a/src/mask.rs
+++ b/src/mask.rs
@@ -132,6 +132,11 @@ impl Mask {
         self.data.as_mut_slice()
     }
 
+    /// Consumes the mask and returns its owned internal data.
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
+    }
+
     pub(crate) fn as_submask(&self) -> SubMaskRef<'_> {
         SubMaskRef {
             size: self.size,

--- a/src/mask.rs
+++ b/src/mask.rs
@@ -133,7 +133,7 @@ impl Mask {
     }
 
     /// Consumes the mask and returns its owned internal data.
-    pub fn into_data(self) -> Vec<u8> {
+    pub fn take(self) -> Vec<u8> {
         self.data
     }
 

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -235,6 +235,24 @@ impl Pixmap {
         self.data.as_mut_slice()
     }
 
+    /// Returns a pixel color.
+    ///
+    /// Returns `None` when position is out of bounds.
+    pub fn pixel(&self, x: u32, y: u32) -> Option<PremultipliedColorU8> {
+        let idx = self.width().checked_mul(y)?.checked_add(x)?;
+        self.pixels().get(idx as usize).cloned()
+    }
+
+    /// Returns a mutable slice of pixels.
+    pub fn pixels_mut(&mut self) -> &mut [PremultipliedColorU8] {
+        bytemuck::cast_slice_mut(self.data_mut())
+    }
+
+    /// Returns a slice of pixels.
+    pub fn pixels(&self) -> &[PremultipliedColorU8] {
+        bytemuck::cast_slice(self.data())
+    }
+
     /// Consumes the internal data.
     ///
     /// Byteorder: RGBA
@@ -256,24 +274,6 @@ impl Pixmap {
                 PremultipliedColorU8::from_rgba_unchecked(c.red(), c.green(), c.blue(), c.alpha());
         }
         self.data
-    }
-
-    /// Returns a pixel color.
-    ///
-    /// Returns `None` when position is out of bounds.
-    pub fn pixel(&self, x: u32, y: u32) -> Option<PremultipliedColorU8> {
-        let idx = self.width().checked_mul(y)?.checked_add(x)?;
-        self.pixels().get(idx as usize).cloned()
-    }
-
-    /// Returns a mutable slice of pixels.
-    pub fn pixels_mut(&mut self) -> &mut [PremultipliedColorU8] {
-        bytemuck::cast_slice_mut(self.data_mut())
-    }
-
-    /// Returns a slice of pixels.
-    pub fn pixels(&self) -> &[PremultipliedColorU8] {
-        bytemuck::cast_slice(self.data())
     }
 
     /// Returns a copy of the pixmap that intersects the `rect`.

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -235,6 +235,13 @@ impl Pixmap {
         self.data.as_mut_slice()
     }
 
+    /// Consumes the pixmap and returns its owned internal data.
+    ///
+    /// Byteorder: RGBA
+    pub fn into_data(self) -> Vec<u8> {
+        self.data
+    }
+
     /// Returns a pixel color.
     ///
     /// Returns `None` when position is out of bounds.

--- a/src/pixmap.rs
+++ b/src/pixmap.rs
@@ -235,31 +235,6 @@ impl Pixmap {
         self.data.as_mut_slice()
     }
 
-    /// Consumes the pixmap and returns its owned internal data.
-    ///
-    /// Byteorder: RGBA
-    pub fn into_data(self) -> Vec<u8> {
-        self.data
-    }
-
-    /// Returns a pixel color.
-    ///
-    /// Returns `None` when position is out of bounds.
-    pub fn pixel(&self, x: u32, y: u32) -> Option<PremultipliedColorU8> {
-        let idx = self.width().checked_mul(y)?.checked_add(x)?;
-        self.pixels().get(idx as usize).cloned()
-    }
-
-    /// Returns a mutable slice of pixels.
-    pub fn pixels_mut(&mut self) -> &mut [PremultipliedColorU8] {
-        bytemuck::cast_slice_mut(self.data_mut())
-    }
-
-    /// Returns a slice of pixels.
-    pub fn pixels(&self) -> &[PremultipliedColorU8] {
-        bytemuck::cast_slice(self.data())
-    }
-
     /// Consumes the internal data.
     ///
     /// Byteorder: RGBA
@@ -281,6 +256,24 @@ impl Pixmap {
                 PremultipliedColorU8::from_rgba_unchecked(c.red(), c.green(), c.blue(), c.alpha());
         }
         self.data
+    }
+
+    /// Returns a pixel color.
+    ///
+    /// Returns `None` when position is out of bounds.
+    pub fn pixel(&self, x: u32, y: u32) -> Option<PremultipliedColorU8> {
+        let idx = self.width().checked_mul(y)?.checked_add(x)?;
+        self.pixels().get(idx as usize).cloned()
+    }
+
+    /// Returns a mutable slice of pixels.
+    pub fn pixels_mut(&mut self) -> &mut [PremultipliedColorU8] {
+        bytemuck::cast_slice_mut(self.data_mut())
+    }
+
+    /// Returns a slice of pixels.
+    pub fn pixels(&self) -> &[PremultipliedColorU8] {
+        bytemuck::cast_slice(self.data())
     }
 
     /// Returns a copy of the pixmap that intersects the `rect`.


### PR DESCRIPTION
I accidentally pushed this to main (reverted it now); sorry about that.

It's nice to be able to create a `Pixmap` or `Mask`, draw into it, and then take its raw data back directly without having to do any cloning; this is a common pattern when interoperating with other libraries that have their own bitmap types.