### PR TITLE
Fix `rustup run nightly cargo bench`

### DIFF
--- a/benches/src/png_io.rs
+++ b/benches/src/png_io.rs
@@ -2,7 +2,13 @@ use test::Bencher;
 
 #[bench]
 fn decode_rgb(bencher: &mut Bencher) {
-    let data = std::fs::read("../tests/images/pngs/rgb.png").unwrap();
+    let filename = "tests/images/pngs/rgb.png";
+    let data = std::fs::read(filename).unwrap_or_else(|err| {
+        panic!(
+            "{err}\nFile: {filename}\nCurrent Working Directory: {wd:?}",
+            wd = std::env::current_dir()
+        );
+    });
     bencher.iter(|| {
         let _ = tiny_skia::Pixmap::decode_png(&data).unwrap();
     });
@@ -10,7 +16,7 @@ fn decode_rgb(bencher: &mut Bencher) {
 
 #[bench]
 fn decode_rgba(bencher: &mut Bencher) {
-    let data = std::fs::read("../tests/images/pngs/rgba.png").unwrap();
+    let data = std::fs::read("tests/images/pngs/rgba.png").unwrap();
     bencher.iter(|| {
         let _ = tiny_skia::Pixmap::decode_png(&data).unwrap();
     });
@@ -20,10 +26,11 @@ fn decode_rgba(bencher: &mut Bencher) {
 // to see how much overhead our code has.
 #[bench]
 fn decode_raw_rgb(bencher: &mut Bencher) {
-    let data = std::fs::read("../tests/images/pngs/rgb.png").unwrap();
+    let data = std::fs::read("tests/images/pngs/rgb.png").unwrap();
     let mut img_data = vec![0; 30000];
     bencher.iter(|| {
-        let decoder = png::Decoder::new(data.as_slice());
+        let reader = std::io::BufReader::new(std::io::Cursor::new(&data));
+        let decoder = png::Decoder::new(reader);
         let mut reader = decoder.read_info().unwrap();
         let _ = reader.next_frame(&mut img_data).unwrap();
     });
@@ -31,10 +38,11 @@ fn decode_raw_rgb(bencher: &mut Bencher) {
 
 #[bench]
 fn decode_raw_rgba(bencher: &mut Bencher) {
-    let data = std::fs::read("../tests/images/pngs/rgba.png").unwrap();
+    let data = std::fs::read("tests/images/pngs/rgba.png").unwrap();
     let mut img_data = vec![0; 40000];
     bencher.iter(|| {
-        let decoder = png::Decoder::new(data.as_slice());
+        let reader = std::io::BufReader::new(std::io::Cursor::new(&data));
+        let decoder = png::Decoder::new(reader);
         let mut reader = decoder.read_info().unwrap();
         let _ = reader.next_frame(&mut img_data).unwrap();
     });
@@ -42,7 +50,7 @@ fn decode_raw_rgba(bencher: &mut Bencher) {
 
 #[bench]
 fn encode_rgba(bencher: &mut Bencher) {
-    let pixmap = tiny_skia::Pixmap::load_png("../tests/images/pngs/rgba.png").unwrap();
+    let pixmap = tiny_skia::Pixmap::load_png("tests/images/pngs/rgba.png").unwrap();
     bencher.iter(|| {
         let _ = pixmap.encode_png().unwrap();
     });
@@ -50,7 +58,7 @@ fn encode_rgba(bencher: &mut Bencher) {
 
 #[bench]
 fn encode_raw_rgba(bencher: &mut Bencher) {
-    let pixmap = tiny_skia::Pixmap::load_png("../tests/images/pngs/rgba.png").unwrap();
+    let pixmap = tiny_skia::Pixmap::load_png("tests/images/pngs/rgba.png").unwrap();
     bencher.iter(|| {
         let mut data = Vec::new();
 


### PR DESCRIPTION
# Compile errors

- Png decoding requires a `BufReader`

# Runtime errors

- Fixed test paths when using `cargo bench`.
- Improved the error message to make easier to debug "file not found" crashes.